### PR TITLE
fix(goat): render GoAT correctly in dark mode (v2.6.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Kroki Server Configuration
 
 # Version Information
-VERSION=2.6.0
-BUILD_DATE=2026-05-28
+VERSION=2.6.1
+BUILD_DATE=2026-06-01
 AUTHOR_NAME="Vysakh Pillai"
 
 # Port Configuration (single values only)

--- a/demoSite/js/modules/diagramApi.js
+++ b/demoSite/js/modules/diagramApi.js
@@ -10,6 +10,7 @@ import { api } from './api.js';
 import { createTrackedBlobUrl } from './dom.js';
 import { DEFAULT_POST_REQUEST_TIMEOUT } from './constants.js';
 import { encodeKrokiDiagram } from './diagramOperations.js';
+import { diagramOptionsQuery, diagramOptionsObject } from './diagramOptions.js';
 
 /**
  * Build the base URL for Kroki API requests
@@ -43,7 +44,7 @@ function getTimeout() {
  * @returns {Promise<string>} Blob URL for the diagram
  */
 export async function generateDiagramWithPost(diagramType, outputFormat, diagramCode) {
-    const postUrl = `${getBaseUrl()}/${diagramType}/${outputFormat}`;
+    const postUrl = `${getBaseUrl()}/${diagramType}/${outputFormat}${diagramOptionsQuery(diagramType)}`;
     const blob = await api.postBlob(postUrl, diagramCode, { timeout: getTimeout() });
     return createTrackedBlobUrl(blob);
 }
@@ -64,6 +65,8 @@ export async function generateDiagramWithJsonPost(diagramType, outputFormat, dia
         diagram_type: diagramType,
         output_format: outputFormat
     };
+    const opts = diagramOptionsObject(diagramType);
+    if (opts) body.diagram_options = opts;
     const blob = await api.postJSON(postUrl, body, { parseAs: 'blob', timeout: getTimeout() });
     return createTrackedBlobUrl(blob);
 }

--- a/demoSite/js/modules/diagramOptions.js
+++ b/demoSite/js/modules/diagramOptions.js
@@ -1,0 +1,42 @@
+/**
+ * Per-diagram-type Kroki render options.
+ *
+ * Some Kroki renderers need a fixed render option to display correctly in the
+ * editor. GoAT emits a prefers-color-scheme-adaptive SVG: its content is drawn
+ * with `currentColor`, which it sets to white under `@media (prefers-color-scheme:
+ * dark)`. In a dark-mode OS that makes GoAT render white, which collides with the
+ * editor's dark-mode diagram handling (white backdrop + invert) and shows as a
+ * black square. Forcing the dark-scheme color to black makes GoAT render black
+ * like every other (black-on-transparent) diagram, so the app's theming works
+ * uniformly. GoAT is the only Kroki renderer that adapts to the OS scheme.
+ *
+ * This module has no browser or third-party dependencies so it stays unit-testable.
+ *
+ * @module diagramOptions
+ */
+
+/** @type {Object.<string, Object.<string,string>>} */
+const DIAGRAM_OPTIONS = {
+    goat: { 'svg-color-dark-scheme': '#000000' },
+};
+
+/**
+ * Kroki render options for a type as a URL query string (e.g. "?k=v"), or "".
+ * Values are URL-encoded (e.g. "#000000" -> "%23000000").
+ * @param {string} diagramType
+ * @returns {string}
+ */
+export function diagramOptionsQuery(diagramType) {
+    const opts = DIAGRAM_OPTIONS[diagramType];
+    if (!opts) return '';
+    return '?' + Object.entries(opts).map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
+}
+
+/**
+ * Kroki render options for a type as an object (for the JSON POST body), or null.
+ * @param {string} diagramType
+ * @returns {Object|null}
+ */
+export function diagramOptionsObject(diagramType) {
+    return DIAGRAM_OPTIONS[diagramType] || null;
+}

--- a/demoSite/js/modules/diagramRenderer.js
+++ b/demoSite/js/modules/diagramRenderer.js
@@ -21,6 +21,7 @@ import { createTrackedBlobUrl, revokeBlobUrl } from './dom.js';
 import { showBanner, hideBanner } from './errors.js';
 import { encodeKrokiDiagram } from './diagramOperations.js';
 import { generateDiagramWithPost, generateDiagramWithJsonPost, fetchDiagramViaPost } from './diagramApi.js';
+import { diagramOptionsQuery } from './diagramOptions.js';
 import { updateUrl, clearUrlParameters } from './urlHandler.js';
 import { api } from './api.js';
 
@@ -73,7 +74,7 @@ export async function updateDiagram() {
         const protocol = window.location.protocol;
         const hostname = window.location.hostname;
         const port = window.location.port ? `:${window.location.port}` : '';
-        const url = `${protocol}//${hostname}${port}/${diagramType}/${outputFormat}/${encodedDiagram}`;
+        const url = `${protocol}//${hostname}${port}/${diagramType}/${outputFormat}/${encodedDiagram}${diagramOptionsQuery(diagramType)}`;
 
         const shouldUsePost = alwaysUsePost || url.length > urlLengthThreshold;
 

--- a/demoSite/tests/diagramOptions.test.js
+++ b/demoSite/tests/diagramOptions.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { diagramOptionsQuery, diagramOptionsObject } from '../js/modules/diagramOptions.js';
+
+// GoAT emits a prefers-color-scheme-adaptive SVG that renders white in OS dark
+// mode, colliding with the editor's dark-mode handling (it showed as a black
+// square in production). We force GoAT's dark-scheme color to black via Kroki's
+// `svg-color-dark-scheme` render option so it renders like every other diagram.
+
+test('goat gets svg-color-dark-scheme forced to black, URL-encoded', () => {
+    assert.equal(diagramOptionsQuery('goat'), '?svg-color-dark-scheme=%23000000');
+});
+
+test('the # in the color is URL-encoded as %23 (must not break the URL)', () => {
+    assert.ok(diagramOptionsQuery('goat').includes('%23'));
+    assert.ok(!diagramOptionsQuery('goat').includes('#'));
+});
+
+test('types without special options get no query string', () => {
+    for (const t of ['plantuml', 'graphviz', 'mermaid', 'd2', 'bpmn']) {
+        assert.equal(diagramOptionsQuery(t), '', `${t} should have no options`);
+    }
+});
+
+test('diagramOptionsObject returns the options map for goat (JSON POST body)', () => {
+    assert.deepEqual(diagramOptionsObject('goat'), { 'svg-color-dark-scheme': '#000000' });
+});
+
+test('diagramOptionsObject returns null for types without options', () => {
+    assert.equal(diagramOptionsObject('plantuml'), null);
+    assert.equal(diagramOptionsObject('graphviz'), null);
+});


### PR DESCRIPTION
## Problem

GoAT diagrams did not render in production for dark-mode users — they showed as a **black square** with **no console error**, while the backend returned **200 OK + a valid SVG** (confirmed in nginx + core logs).

## Root cause

GoAT is the **only Kroki renderer that emits a `prefers-color-scheme`-adaptive SVG**. Its content is drawn with `currentColor`, which it sets to **white** under `@media (prefers-color-scheme: dark)`:

```css
@media (prefers-color-scheme: dark) { svg { color: #FFF; } }
svg { fill: currentColor; stroke: currentColor; }
```

In a dark-mode OS the GoAT SVG renders white. That collides with the editor's dark-mode diagram handling (white `#diagram` backdrop + the `.diagram-inverted` invert filter): white-on-white, inverted → **black-on-black = a black square**. Other renderers (PlantUML/Graphviz/etc.) emit fixed-black SVGs, so only GoAT was affected. This is why a hard refresh didn't help (not a cache issue) and there was no error (the SVG is valid — just the wrong color).

## Fix

Force GoAT's dark-scheme color to black via Kroki's `svg-color-dark-scheme=#000000` render option, so GoAT renders black like every other diagram and the app's existing theming works uniformly. **Verified server-side**: `…/goat/svg/<enc>?svg-color-dark-scheme=%23000000` flips the SVG's dark-scheme color from `#FFF` → `#000000`.

Implemented as a dependency-free `diagramOptions.js` leaf module, applied across all three request shapes:
- GET render URL (`diagramRenderer.js`) — also keeps shared image links correct
- plain POST (`generateDiagramWithPost`)
- JSON POST (`generateDiagramWithJsonPost`, via `diagram_options` body field)

## Tests

New `tests/diagramOptions.test.js` (5 cases: goat option + URL-encoding of `#`, other types get no options, JSON-body object form). Full suite: **39 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)