### PR TITLE
feat(app-server): run gunicorn instead of the Flask dev server (PR-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,27 @@ AI_TIMEOUT=30
 # Hard ceiling for client-requested AI timeouts (seconds)
 AI_TIMEOUT_MAX=300
 
+# --- App server (gunicorn) tuning --------------------------------------------
+# Concurrency ceiling = GUNICORN_WORKERS x GUNICORN_THREADS in-flight requests.
+# Each streaming AI request holds one thread for up to AI_TIMEOUT_MAX seconds.
+# WARNING: the AI rate limit (/api/ai-assist) is tracked per worker process
+# (in-memory store), so the effective per-IP cap is approximately
+# GUNICORN_WORKERS x the configured limit until the store is backed by Redis
+# (Phase 2). For example, with GUNICORN_WORKERS=2 and the default 10/min
+# limit, a single IP can make ~20 AI requests per minute.
+#GUNICORN_WORKERS=2
+#GUNICORN_THREADS=8
+#GUNICORN_TIMEOUT=30
+#GUNICORN_GRACEFUL_TIMEOUT=30
+#GUNICORN_KEEPALIVE=5
+#GUNICORN_LOG_LEVEL=info
+
 # AI endpoint security
 # SESSION_SECRET: signs the per-browser session cookie required by /api/ai-assist.
 #   Leave unset to use a random secret per server start (sessions reset on restart).
+#   With preload_app=True (gunicorn.conf.py), all workers in a single container
+#   share the master's per-boot secret automatically — SESSION_SECRET is only
+#   required for multi-container/replica deployments.
 #SESSION_SECRET=""
 # AI_ACCESS_TOKEN: optional shared bearer token for /api/ai-assist. When set,
 #   every AI request must present it (Authorization: Bearer <token>); use this

--- a/README.md
+++ b/README.md
@@ -366,6 +366,21 @@ cd kroki-server
 ./setup-kroki-server.sh restart
 ```
 
+### Dev server vs. production (gunicorn)
+
+The DocCode container runs **gunicorn** (gthread worker, `GUNICORN_WORKERS × GUNICORN_THREADS` concurrency) — not the Flask dev server. For bare local development outside Docker, `python demoSite/server.py` still works (single Werkzeug process), but must not be exposed publicly.
+
+Tune the production app server via `.env`:
+
+```bash
+GUNICORN_WORKERS=2        # processes (default: 2)
+GUNICORN_THREADS=8        # threads per worker (default: 8)
+GUNICORN_GRACEFUL_TIMEOUT=30  # drain window on SIGTERM (seconds)
+GUNICORN_LOG_LEVEL=info   # gunicorn log verbosity
+```
+
+See `demoSite/gunicorn.conf.py` for all tunable parameters and their rationale.
+
 ## License & Attribution
 
 - **License**: MIT License

--- a/demoSite/Dockerfile
+++ b/demoSite/Dockerfile
@@ -22,6 +22,7 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # Copy application files
 COPY --chown=appuser:appgroup server.py .
+COPY --chown=appuser:appgroup gunicorn.conf.py .
 COPY --chown=appuser:appgroup ai-models.json .
 COPY --chown=appuser:appgroup index.html .
 COPY --chown=appuser:appgroup favicon.ico .
@@ -35,7 +36,9 @@ RUN find /app -type d -exec chmod 755 {} \; && \
     chmod +x /app/server.py
 
 # Add healthcheck using the dedicated health endpoint
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+# start-period=30s covers the pre-existing import-time proxy /models fetch
+# (server.py:264, 10s timeout) plus gunicorn master+worker spawn time.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${PORT}/api/health || exit 1
 
 # Expose the port (for documentation)
@@ -45,4 +48,4 @@ EXPOSE ${PORT}
 USER appuser
 
 # Use exec form of CMD for proper signal handling
-CMD ["python", "server.py"]
+CMD ["gunicorn", "--config", "/app/gunicorn.conf.py", "server:app"]

--- a/demoSite/gunicorn.conf.py
+++ b/demoSite/gunicorn.conf.py
@@ -1,0 +1,52 @@
+"""Gunicorn config for the DocCode app container.
+
+Tunables (set in .env; compose forwards it via env_file):
+  GUNICORN_WORKERS, GUNICORN_THREADS, GUNICORN_TIMEOUT,
+  GUNICORN_GRACEFUL_TIMEOUT, GUNICORN_KEEPALIVE, GUNICORN_LOG_LEVEL
+"""
+import os
+
+
+def _env(name, default):
+    """Return env var value, falling back to default on missing or empty string.
+
+    An uncommented-but-empty var in .env (e.g. GUNICORN_WORKERS=) is forwarded
+    as an empty string by compose env_file; `or default` catches that case so
+    the container never crash-loops with a ValueError from int('').
+    """
+    return os.environ.get(name) or default
+
+
+bind = f"0.0.0.0:{_env('PORT', '8006')}"
+
+worker_class = "gthread"
+workers = int(_env("GUNICORN_WORKERS", "2"))
+threads = int(_env("GUNICORN_THREADS", "8"))
+
+# Liveness heartbeat, NOT a per-request limit: gthread workers keep notifying
+# the master while threads stream SSE, so 300s AI streams survive this.
+timeout = int(_env("GUNICORN_TIMEOUT", "30"))
+
+# Drain window after SIGTERM; in-flight AI streams longer than this are cut on
+# deploy. Must stay below stop_grace_period in docker-compose.yml (35s).
+graceful_timeout = int(_env("GUNICORN_GRACEFUL_TIMEOUT", "30"))
+
+# Behind nginx keepalive upstream connections are cheap; gunicorn default is 2s.
+keepalive = int(_env("GUNICORN_KEEPALIVE", "5"))
+
+# Import server.py once in the master, then fork: every worker shares the same
+# per-boot SESSION_SECRET (server.py:86), so session cookies validate on any
+# worker even when SESSION_SECRET is unset (the closed-network default).
+# Without preload each worker would mint its own secret -> intermittent 401s.
+# Reproduced empirically with gunicorn 26.0.0: without preload, 2 workers
+# served 2 different secrets; with preload, both workers shared one secret.
+preload_app = True
+
+# Heartbeat tempfiles on tmpfs so a slow disk can never stall a worker.
+worker_tmp_dir = "/dev/shm"
+
+accesslog = "-"
+errorlog = "-"
+loglevel = _env("GUNICORN_LOG_LEVEL", "info")
+# Apache-style + request duration: %(L)s = request time in decimal seconds.
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)ss'

--- a/demoSite/requirements.txt
+++ b/demoSite/requirements.txt
@@ -4,3 +4,4 @@ Flask-Limiter==4.1.1
 requests==2.34.2
 Werkzeug==3.1.8
 python-dotenv==1.2.2
+gunicorn==26.0.0

--- a/demoSite/server.py
+++ b/demoSite/server.py
@@ -717,6 +717,9 @@ def static_files(filename):
         return "File not found", 404
 
 if __name__ == '__main__':
+    # Bare local development ONLY (`python server.py`, single Werkzeug process).
+    # The container runs gunicorn via demoSite/gunicorn.conf.py (see Dockerfile
+    # CMD); do not use this path in production.
     logger.info(f"Starting Kroki Demo Site Server on port {PORT}")
     logger.info(f"Static files served from: {STATIC_ROOT}")
     logger.info(f"AI Assistant enabled: {DEFAULT_AI_CONFIG['enabled']}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
 
   demosite:
     restart: unless-stopped
+    stop_grace_period: 35s
     image: kroki-demosite:latest
     expose:
       - "${DEMOSITE_CONTAINER_PORT:-8006}"


### PR DESCRIPTION
## Summary

PR-2 of the [public-hosting plan](docs/public-hosting-plan-2026-06-12.md) (§4): the app container now runs **gunicorn 26.0.0** (gthread workers) instead of the Werkzeug dev server.

- `demoSite/gunicorn.conf.py` (new): gthread, env-tunable `GUNICORN_WORKERS×THREADS` (default 2×8 = 16 in-flight requests on a 2 vCPU box), `preload_app=True` so all forked workers share the per-boot `SESSION_SECRET` (without preload, each worker mints its own secret → intermittent 401s — reproduced empirically), `/dev/shm` heartbeat dir, stdout access logs with request timing.
- Dockerfile: `CMD gunicorn --config gunicorn.conf.py server:app`; HEALTHCHECK start-period 10s→30s (covers the pre-existing import-time proxy `/models` fetch).
- compose: `stop_grace_period: 35s` on demosite (must exceed `graceful_timeout=30`, else docker SIGKILLs at its 10s default).
- `.env.example`: GUNICORN_* tuning block + the per-worker rate-limiter multiplication warning (Redis store is Phase 2); SESSION_SECRET guidance updated (optional for single-container deployments of any worker count, thanks to preload).
- `python server.py` remains the documented bare-local-dev path (comment-only change).

The 30s gunicorn `timeout` is a liveness heartbeat, not a per-request limit — gthread workers keep notifying the master during long SSE streams, so 300s AI streams survive it (verified empirically during planning and re-verified here).

## Verification

- pytest 21/21 unchanged; real gunicorn boot: `/api/health` 200, 1 master + 2 workers.
- Cross-worker session check: 16 requests, zero 401s (the preload guarantee).
- Docker image builds and runs gunicorn (verified via `docker top`); graceful SIGTERM shutdown ("Worker exiting", no SIGKILL).
- `docker compose config -q` clean.

Rollback: revert the Dockerfile CMD to `python server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)