### PR TITLE
feat(ai): three-state AI mode, free-tier allowlist, and the BYOK privacy guarantee (PR-3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,33 @@ HOSTNAME=localhost
 # Proxy supports: LiteLLM, OpenRouter, or any OpenAI-compatible API
 AI_ENABLED=true
 AI_PROXY_URL=https://openrouter.ai/api/v1
+# WARNING: every /api/ai-assist call spends THIS key. Before exposing this
+# server publicly, set AI_MODEL_ALLOWLIST (below) to pin cheap/free models,
+# set AI_DAILY_LIMIT_PER_IP to cap per-user spend, or leave AI_PROXY_API_KEY
+# empty to run in BYOK mode (relay disabled; users bring their own key).
 AI_PROXY_API_KEY=""
 AI_PROXY_NAME="OpenRouter"
-AI_MODEL=openai/gpt-4o
+# Default model. gpt-4o-mini is the cost-conscious default; pick a stronger
+# model only if you accept the per-request cost on your relay key.
+AI_MODEL=openai/gpt-4o-mini
 AI_MAX_TOKENS=16000
 AI_TIMEOUT=30
 # Hard ceiling for client-requested AI timeouts (seconds)
 AI_TIMEOUT_MAX=300
+
+# Optional curated model allowlist (comma-separated glob patterns).
+# Only models matching at least one pattern are exposed in the UI and relayed.
+# Empty = allow all (current behavior). Example for OpenRouter free-tier relay:
+#AI_MODEL_ALLOWLIST="*:free"
+
+# Ordered fallback chain tried at startup when AI_MODEL is absent from the
+# filtered model list (free-roster churn means the default can vanish monthly).
+#AI_MODEL_FALLBACKS="meta-llama/llama-3.3-70b-instruct:free,openai/gpt-oss-120b:free"
+
+# Per-IP daily cap on /api/ai-assist (flask-limiter format, semicolon-separated).
+# Protects the shared relay pool from single-user exhaustion. Empty = no extra limit.
+# Note: stored per-worker in-memory (resets on deploy / gunicorn restart); Redis is Phase 2.
+#AI_DAILY_LIMIT_PER_IP="10/minute;30/day"
 
 # --- App server (gunicorn) tuning --------------------------------------------
 # Concurrency ceiling = GUNICORN_WORKERS x GUNICORN_THREADS in-flight requests.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ After editing `.env`, restart the services:
 
 DocCode includes a powerful AI assistant that can generate, modify, and explain diagrams using natural language.
 
+### AI assistant deployment modes
+
+The server advertises one of three AI postures depending on your `.env`:
+
+| Mode | When | Behaviour |
+|---|---|---|
+| `relay` | `AI_ENABLED=true` + `AI_PROXY_API_KEY` set | Server proxies requests on its own key. The closed-network default and the public-demo configuration. |
+| `byok` | `AI_ENABLED=true` + `AI_PROXY_API_KEY` empty | Relay unusable; the assistant UI stays visible and guides users to bring their own OpenAI-compatible key. Requests go directly from the browser to the user's provider — the key never reaches this server. |
+| `off` | `AI_ENABLED=false` | Assistant button hidden; true kill switch. |
+
+The mode is computed at startup from exactly those two variables — there is no single "public" switch. The public-demo posture is an explicit `.env` bundle (see `docs/public-hosting-plan-2026-06-12.md` §6).
+
+**Relay self-hosters:** the relay spends `AI_PROXY_API_KEY` on every assistant request. Before exposing a relay-enabled instance beyond a trusted network:
+- Set `AI_MODEL_ALLOWLIST` to pin cheap/free models (e.g. `"*:free"` on OpenRouter).
+- Set `AI_DAILY_LIMIT_PER_IP` to cap per-user spend (e.g. `"10/minute;30/day"`).
+- Or leave `AI_PROXY_API_KEY` empty to run in `byok` mode (zero relay cost).
+
+**BYOK privacy guarantee:** in `byok` mode (or when users enable "Use Direct API" in Settings), the API key is stored only in the browser (localStorage) and sent only to the endpoint the user configures — never to the DocCode server. This is structurally enforced in code and locked by regression tests. See [docs/byok-privacy.md](docs/byok-privacy.md) for the full guarantee and DevTools verification steps.
+
 ### Quick AI Setup (Recommended)
 
 **Using OpenRouter** (supports 50+ models from multiple providers):
@@ -109,7 +128,7 @@ AI_ENABLED=true
 AI_PROXY_URL=https://openrouter.ai/api/v1
 AI_PROXY_API_KEY=sk-or-v1-your-api-key-here
 AI_PROXY_NAME="OpenRouter"
-AI_MODEL=openai/gpt-4o
+AI_MODEL=openai/gpt-4o-mini
 
 # 3. Restart services
 ./setup-kroki-server.sh restart

--- a/demoSite/js/ai-assistant-api.js
+++ b/demoSite/js/ai-assistant-api.js
@@ -78,6 +78,12 @@ window.AIAssistantAPI = {
      * @returns {Promise<string|Object>}
      */
     async callProxyAPI(messages, config, abortController, callbacks) {
+        // H1: structural impossibility guard — the BYOK key must never travel to
+        // the DocCode origin. If the selector ever regresses, fail loud here.
+        if (config.useCustomAPI && config.apiKey) {
+            throw new Error('proxy path must not run in custom mode');
+        }
+
         const controller = abortController || new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), (config.timeout || 30) * 1000);
 
@@ -94,10 +100,9 @@ window.AIAssistantAPI = {
                     maxRetryAttempts: config.maxRetryAttempts,
                     max_tokens: AI_API_MAX_TOKENS,
                     stream: true,
+                    // H1: never send endpoint or api_key to the DocCode origin —
+                    // only the timeout is a valid server-side config parameter.
                     config: {
-                        use_custom_api: config.useCustomAPI,
-                        endpoint: config.endpoint,
-                        api_key: config.apiKey,
                         timeout: config.timeout
                     }
                 }),
@@ -106,6 +111,13 @@ window.AIAssistantAPI = {
 
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}));
+                // Surface quota codes so the caller can render the right UI state
+                if (errorData.code) {
+                    const err = new Error(errorData.error || this._getHttpErrorMessage(response.status));
+                    err.quotaCode = errorData.code;
+                    err.retryAfter = errorData.retry_after;
+                    throw err;
+                }
                 throw new Error(errorData.error || this._getHttpErrorMessage(response.status));
             }
 

--- a/demoSite/js/ai-assistant.js
+++ b/demoSite/js/ai-assistant.js
@@ -47,6 +47,10 @@ class AIAssistant {
         // Configuration
         this.configManager = configManager;
 
+        // Server-advertised AI mode ('relay' | 'byok' | 'off'); set by applyServerMode()
+        this.serverAIMode = null;
+        this.byokOnboardingNeeded = false;
+
         // Event listener references for cleanup
         this._boundListeners = [];
 
@@ -262,11 +266,26 @@ class AIAssistant {
     }
 
     openChat() {
+        // Guard: if server mode is 'off', do not open (button should be hidden anyway)
+        if (this.serverAIMode === 'off') return;
+
         this.isOpen = true;
         this.assistButton.style.display = 'none';
         this.chatWindow.style.display = 'block';
         this.positionChatWindow();
         this.updateModelIndicator();
+
+        // BYOK onboarding: show once on first open when no key is configured
+        if (this.byokOnboardingNeeded) {
+            this.byokOnboardingNeeded = false;
+            this.addMessage('system',
+                'This server does not provide an AI backend. To use the assistant, ' +
+                'add your own OpenAI-compatible endpoint and API key in the ' +
+                '<button onclick="window.aiAssistant?.openSettings()">AI Settings</button>. ' +
+                'Your key stays only in your browser — it is never sent to our server.',
+                true);
+        }
+
         this.chatInput.focus();
         this.scrollToBottom();
     }
@@ -274,7 +293,10 @@ class AIAssistant {
     closeChat() {
         this.isOpen = false;
         this.chatWindow.style.display = 'none';
-        this.assistButton.style.display = 'flex';
+        // Guard: do not re-show the button when mode is 'off' (it is already hidden)
+        if (this.serverAIMode !== 'off') {
+            this.assistButton.style.display = 'flex';
+        }
         this.clearChatHistory();
         this.clearMessageHistory();
     }
@@ -293,6 +315,7 @@ class AIAssistant {
     }
 
     minimizeChat() {
+        if (this.serverAIMode === 'off') return;
         this.isOpen = false;
         this.chatWindow.style.display = 'none';
         this.assistButton.style.display = 'flex';
@@ -533,14 +556,21 @@ class AIAssistant {
             return;
         }
 
-        try {
-            const isValidModel = await window.AIAssistantAPI.validateModel(selectedModel);
-            if (!isValidModel) {
-                this.addMessage('system', `Model "${selectedModel}" is not available. Please select a different model in the <button onclick="window.aiAssistant?.openSettings()">settings</button>.`, true);
-                return;
+        // BYOK model-validation fix: skip server allowlist check in custom mode —
+        // AVAILABLE_MODELS is empty in byok mode and would block every send.
+        if (!aiConfig.useCustomAPI) {
+            try {
+                const isValidModel = await window.AIAssistantAPI.validateModel(selectedModel);
+                if (!isValidModel) {
+                    // H2: escape user-controlled selectedModel before rawHtml=true injection
+                    const esc = s => String(s).replace(/[&<>"']/g, c =>
+                        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+                    this.addMessage('system', `Model "${esc(selectedModel)}" is not available. Please open <button onclick="window.aiAssistant?.openSettings()">settings</button> to select a different model.`, true);
+                    return;
+                }
+            } catch (error) {
+                console.warn('Model validation failed:', error);
             }
-        } catch (error) {
-            console.warn('Model validation failed:', error);
         }
 
         try {
@@ -648,6 +678,12 @@ class AIAssistant {
             }
         } catch (error) {
             if (!this.isRequestInProgress) return;
+
+            // Quota errors must not be retried — render the specific UI state immediately.
+            if (error.quotaCode) {
+                this._renderQuotaMessage(error.quotaCode, error.retryAfter);
+                return;
+            }
 
             if (this.retryAttempts < aiConfig.maxRetryAttempts) {
                 if (!this.isRequestInProgress) return;
@@ -973,6 +1009,76 @@ class AIAssistant {
         if (!modelName) return 'Unknown';
         const parts = modelName.split('/');
         return parts.length > 1 ? parts.slice(1).join('/') : modelName;
+    }
+
+    /**
+     * Apply the server-advertised AI mode with all critique fixes.
+     * Called from main.js after /api/config resolves.
+     * @param {'relay'|'byok'|'off'} mode
+     */
+    applyServerMode(mode) {
+        this.serverAIMode = mode;
+
+        if (mode === 'off') {
+            // closeChat() re-shows the button; call it BEFORE hiding so the guard
+            // in closeChat() suppresses the re-show.
+            if (this.isOpen) this.closeChat();
+            if (this.assistButton) this.assistButton.style.display = 'none';
+            return;
+        }
+
+        if (mode === 'byok' && this.configManager) {
+            // Relay is off server-side; direct API is the only working path.
+            // Always force useCustomAPI=true and re-run toggleDependentFields so
+            // the dependent endpoint/key inputs become enabled (programmatic
+            // .checked fires no change event — state-sync critique fix).
+            this.configManager.set('ai.useCustomAPI', true);
+            if (window.configUI && typeof window.configUI.toggleDependentFields === 'function') {
+                const cb = document.getElementById('ai-use-custom-api');
+                if (cb) cb.checked = true;
+                window.configUI.toggleDependentFields();
+            }
+            // Queue the one-time onboarding message (shown in openChat)
+            if (!this.configManager.get('ai.apiKey')) {
+                this.byokOnboardingNeeded = true;
+            }
+        }
+    }
+
+    /**
+     * Render a quota-exhausted system message for relay 429 responses.
+     * @param {string} code - 'free_quota_exhausted' | 'per_ip_quota'
+     * @param {string|null} retryAfter
+     */
+    _renderQuotaMessage(code, retryAfter) {
+        if (code === 'free_quota_exhausted') {
+            // Show the shared-pool copy with a button that pre-fills OpenRouter
+            this.addMessage('system',
+                '<strong>The shared free AI quota for this demo is used up for today.</strong><br>' +
+                'This demo runs on OpenRouter\'s free tier, which everyone here shares. ' +
+                'It resets daily — or you can keep going right now with your own free key:<br>' +
+                '1. Sign up at <a href="https://openrouter.ai" target="_blank" rel="noopener">openrouter.ai</a> (email or Google — no credit card).<br>' +
+                '2. Create a key under <strong>Keys</strong>, and in <strong>Settings → Privacy</strong>, enable free endpoints ("training/logging") so <code>:free</code> models work.<br>' +
+                '3. <button onclick="window.aiAssistant?._openOpenRouterSettings()">Open AI Settings</button> and paste your key under "Use my own API key".<br>' +
+                'Your key stays in your browser — it is never sent to our server.<br>' +
+                'You\'ll get your own 50 free requests/day. Everything else in DocCode works without AI.',
+                true);
+        } else if (code === 'per_ip_quota') {
+            this.addMessage('system',
+                'You\'ve hit this demo\'s per-user AI limit for today. ' +
+                'Add your own free OpenRouter key in <button onclick="window.aiAssistant?.openSettings()">AI Settings</button> to continue without limits.',
+                true);
+        }
+    }
+
+    /**
+     * Open the custom-API settings panel pre-filled with the OpenRouter endpoint.
+     */
+    _openOpenRouterSettings() {
+        if (this.configManager) {
+            this.configManager.set('ai.endpoint', 'https://openrouter.ai/api/v1');
+        }
+        this.openSettings();
     }
 
     /**

--- a/demoSite/js/config-ui-models.js
+++ b/demoSite/js/config-ui-models.js
@@ -38,6 +38,46 @@ window.ConfigUIModels = {
             }
 
             const data = await response.json();
+
+            // BYOK branch: server is not in relay mode — show custom-only UI
+            if (data.mode && data.mode !== 'relay') {
+                modelSelect.innerHTML = '';
+                const customOption = document.createElement('option');
+                customOption.value = 'custom';
+                customOption.textContent = 'Custom Model';
+                customOption.selected = true;
+                modelSelect.appendChild(customOption);
+
+                if (configManager.get('ai.model') !== 'custom') {
+                    configManager.set('ai.model', 'custom');
+                }
+
+                const customField = document.getElementById('custom-model-field');
+                if (customField) customField.style.display = '';
+
+                const customApiToggle = document.getElementById('ai-use-custom-api');
+                if (customApiToggle) {
+                    customApiToggle.checked = true;
+                    customApiToggle.disabled = true;
+                    // Persist the state since programmatic .checked fires no change event
+                    configManager.set('ai.useCustomAPI', true);
+                }
+
+                const desc = document.getElementById('custom-api-description');
+                if (desc) {
+                    desc.textContent = 'This server does not provide a backend AI proxy. ' +
+                        'Enter your own OpenAI-compatible endpoint and API key; ' +
+                        'requests go directly from your browser to the provider.';
+                }
+
+                if (modelDescription) {
+                    modelDescription.textContent = 'No server-side models — enter your model name below (e.g. gpt-4o-mini)';
+                }
+
+                this.updateBackendServiceInfo(data);
+                return;
+            }
+
             this.populateModelSelect(modelSelect, data, configManager);
 
             if (modelDescription) {

--- a/demoSite/js/config-ui-templates.js
+++ b/demoSite/js/config-ui-templates.js
@@ -314,7 +314,7 @@ window.ConfigUITemplates = {
                             <span class="config-checkbox-mark"></span>
                             <span class="config-checkbox-label">Use Direct API (Override Backend Proxy)</span>
                         </label>
-                        <div class="config-description">Enable to use direct API calls from frontend. By default, the backend proxy is used (recommended).</div>
+                        <div class="config-description" id="custom-api-description">Enable to use direct API calls from frontend. By default, the backend proxy is used (recommended).</div>
                     </div>
                     <div class="config-field" data-depends="ai.useCustomAPI">
                         <label class="config-label">AI API URL</label>
@@ -337,6 +337,11 @@ window.ConfigUITemplates = {
                         </div>
                         </form>
                         <div class="config-description">Your direct API key</div>
+                        <div class="config-description config-note">
+                            🔒 Stored only in this browser (localStorage) and sent only to the AI API URL above —
+                            never to the DocCode server.
+                            <a href="/docs/byok-privacy.md" target="_blank" rel="noopener">How to verify</a>.
+                        </div>
                     </div>
                 </div>
             </div>

--- a/demoSite/js/main.js
+++ b/demoSite/js/main.js
@@ -279,6 +279,11 @@ document.addEventListener('DOMContentLoaded', function () {
             if (config.kroki && config.kroki.maxBodySize && window.configManager) {
                 window.configManager.set('editor.maxTextSize', config.kroki.maxBodySize);
             }
+            // Deliver server AI mode to the assistant so the UI reflects relay/byok/off
+            if (config.ai && window.aiAssistant && typeof window.aiAssistant.applyServerMode === 'function') {
+                const mode = config.ai.mode || (config.ai.enabled ? 'relay' : 'off');
+                window.aiAssistant.applyServerMode(mode);
+            }
         })
         .catch(() => { /* server config unavailable, use default */ })
         .finally(() => {

--- a/demoSite/js/modules/validation.js
+++ b/demoSite/js/modules/validation.js
@@ -83,5 +83,7 @@ export function sanitizeString(input, maxLength = MAX_CONFIG_STRING_LENGTH) {
     if (typeof input !== 'string') {
         return String(input);
     }
-    return input.slice(0, maxLength);
+    // H2: strip HTML-significant chars in addition to truncating, so config
+    // values can never carry markup into any innerHTML sink (defense in depth).
+    return input.slice(0, maxLength).replace(/[<>]/g, '');
 }

--- a/demoSite/server.py
+++ b/demoSite/server.py
@@ -4,6 +4,7 @@ Kroki Demo Site Server with AI Assistant API Proxy
 Provides static file serving and AI API proxy functionality
 """
 
+import fnmatch
 import os
 import hashlib
 import hmac
@@ -23,11 +24,11 @@ from datetime import datetime
 try:
     from dotenv import load_dotenv
     import os
-    
+
     # Try to load from parent directory first (top-level .env), then current directory
     parent_env = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
     current_env = os.path.join(os.path.dirname(__file__), '.env')
-    
+
     if os.path.exists(parent_env):
         load_dotenv(parent_env)
         print(f"Loaded environment from: {parent_env}")
@@ -36,7 +37,7 @@ try:
         print(f"Loaded environment from: {current_env}")
     else:
         print("No .env file found, using system environment variables")
-        
+
 except ImportError:
     # dotenv not available, will use system environment variables
     print("dotenv not available, using system environment variables")
@@ -100,10 +101,67 @@ AI_PROXY_NAME = os.environ.get('AI_PROXY_NAME', 'AI Proxy')
 DEFAULT_AI_CONFIG = {
     'proxy_url': AI_PROXY_URL,
     'api_key': AI_PROXY_API_KEY,
-    'model': os.environ.get('AI_MODEL', 'openai/gpt-4o'),
+    'model': os.environ.get('AI_MODEL', 'openai/gpt-4o-mini'),
     'timeout': int(os.environ.get('AI_TIMEOUT', AI_TIMEOUT)),
     'enabled': os.environ.get('AI_ENABLED', 'true').lower() == 'true'
 }
+
+# ---------------------------------------------------------------------------
+# AI mode computation (no PUBLIC_MODE; superseded by user directive)
+# ---------------------------------------------------------------------------
+
+def compute_ai_mode(ai_enabled, has_proxy_key):
+    """Effective AI posture.
+
+    relay - server proxies AI calls on its own key (closed-network default)
+    byok  - relay disabled; UI guides users to bring their own key
+    off   - AI assistant hidden entirely (AI_ENABLED=false)
+    """
+    if not ai_enabled:
+        return 'off'
+    if not has_proxy_key:
+        return 'byok'  # relay enabled but unusable without a key
+    return 'relay'
+
+
+AI_MODE = compute_ai_mode(DEFAULT_AI_CONFIG['enabled'], bool(AI_PROXY_API_KEY))
+
+# ---------------------------------------------------------------------------
+# Model allowlist + startup fallback walk
+# ---------------------------------------------------------------------------
+
+# Comma-separated glob patterns; empty = allow all (current behavior).
+AI_MODEL_ALLOWLIST = [p.strip() for p in os.environ.get('AI_MODEL_ALLOWLIST', '').split(',') if p.strip()]
+# Ordered fallback models tried at startup when AI_MODEL is filtered/absent.
+AI_MODEL_FALLBACKS = [m.strip() for m in os.environ.get('AI_MODEL_FALLBACKS', '').split(',') if m.strip()]
+
+# ---------------------------------------------------------------------------
+# Per-IP daily cap (flask-limiter, active only when the env var is set)
+# ---------------------------------------------------------------------------
+
+AI_DAILY_LIMIT_PER_IP = os.environ.get('AI_DAILY_LIMIT_PER_IP', '')
+
+# ---------------------------------------------------------------------------
+# Quota error copy (verbatim from the plan §3.5)
+# ---------------------------------------------------------------------------
+
+FREE_QUOTA_COPY = (
+    "The shared free AI quota for this demo is used up for today. "
+    "This demo runs on OpenRouter's free tier, which everyone here shares. "
+    "It resets daily — or you can keep going right now with your own free key: "
+    "1. Sign up at openrouter.ai (email or Google — no credit card). "
+    "2. Create a key under Keys, and in Settings → Privacy, enable free endpoints "
+    "(“training/logging”) so :free models work. "
+    "3. Paste the key in AI Settings → Use my own API key. "
+    "Your key stays in your browser — it is never sent to our server. "
+    "You’ll get your own 50 free requests/day. Everything else in DocCode works without AI."
+)
+
+PER_IP_COPY = (
+    "You’ve hit this demo’s per-user AI limit for today. "
+    "Add your own free OpenRouter key in AI Settings to continue without limits."
+)
+
 
 # Load available models from JSON configuration file
 def load_available_models():
@@ -113,17 +171,37 @@ def load_available_models():
         with open(models_file, 'r') as f:
             models = json.load(f)
             logger.info(f"Successfully loaded {len(models)} provider categories from ai-models.json")
-            return models
+            result = apply_model_allowlist(models)
+            return result
     except Exception as e:
         logger.warning(f"Could not load ai-models.json: {e}. Using fallback models.")
         # Fallback models in case file is missing
-        return {
+        fallback = {
             'openai': {
-                'gpt-4o': {'name': 'GPT-4o', 'provider': 'OpenAI', 'context': '128k', 'cost': 'high'},
-                'gpt-4o-mini': {'name': 'GPT-4o Mini', 'provider': 'OpenAI', 'context': '128k', 'cost': 'low'},
-                'gpt-3.5-turbo': {'name': 'GPT-3.5 Turbo', 'provider': 'OpenAI', 'context': '16k', 'cost': 'low'}
+                'openai/gpt-4o': {'name': 'GPT-4o', 'provider': 'OpenAI', 'context': '128k', 'cost': 'high'},
+                'openai/gpt-4o-mini': {'name': 'GPT-4o Mini', 'provider': 'OpenAI', 'context': '128k', 'cost': 'low'},
             }
         }
+        return apply_model_allowlist(fallback)
+
+
+def apply_model_allowlist(grouped):
+    """Filter the {provider: {model_id: info}} dict by allowlist globs.
+
+    Empty list = allow all (current behavior).
+    This is the SINGLE filter point that secures both the UI list and the relay
+    (both read AVAILABLE_MODELS).
+    """
+    if not AI_MODEL_ALLOWLIST:
+        return grouped
+    out = {}
+    for provider, models in grouped.items():
+        kept = {mid: info for mid, info in models.items()
+                if any(fnmatch.fnmatch(mid, pat) for pat in AI_MODEL_ALLOWLIST)}
+        if kept:
+            out[provider] = kept
+    return out
+
 
 # Known non-chat model keywords to filter out
 NON_CHAT_MODEL_KEYWORDS = ['embedding', 'embed', 'tts', 'whisper', 'dall-e', 'moderation']
@@ -192,7 +270,7 @@ def fetch_models_from_proxy():
     """Fetch available models from the LiteLLM proxy /models endpoint at startup.
 
     Returns a dict grouped by provider prefix in the same shape as ai-models.json,
-    or None if the proxy is unreachable.
+    filtered through the allowlist, or None if the proxy is unreachable.
     """
     if not AI_PROXY_URL or not AI_PROXY_API_KEY:
         logger.warning("AI_PROXY_URL or AI_PROXY_API_KEY not configured, skipping proxy model fetch")
@@ -239,6 +317,9 @@ def fetch_models_from_proxy():
         if skipped:
             logger.info(f"Filtered out {len(skipped)} non-chat models: {skipped}")
 
+        # Apply allowlist filter at the single filter point
+        grouped = apply_model_allowlist(grouped)
+
         total = sum(len(m) for m in grouped.values())
         logger.info(f"Fetched {total} chat models from proxy across {len(grouped)} providers")
         return grouped if grouped else None
@@ -260,15 +341,53 @@ def fetch_models_from_proxy():
 BOLD_RED = '\033[1;31m'
 RESET = '\033[0m'
 
-# Try proxy first, fall back to static JSON
-_proxy_models = fetch_models_from_proxy()
-if _proxy_models:
-    AVAILABLE_MODELS = _proxy_models
-    logger.info("Using model list from LLM proxy")
+# Try proxy first, fall back to static JSON (only in relay mode)
+if AI_MODE != 'relay':
+    AVAILABLE_MODELS = {}
+    logger.info(f"AI mode '{AI_MODE}': relay disabled, skipping proxy model fetch")
 else:
-    AVAILABLE_MODELS = load_available_models()
-    print(f"{BOLD_RED}WARNING: Failed to fetch models from LLM proxy. Using static fallback (ai-models.json).{RESET}")
-    logger.warning("Failed to fetch models from LLM proxy. Using static fallback (ai-models.json).")
+    _proxy_models = fetch_models_from_proxy()
+    if _proxy_models:
+        AVAILABLE_MODELS = _proxy_models
+        logger.info("Using model list from LLM proxy")
+    else:
+        AVAILABLE_MODELS = load_available_models()
+        print(f"{BOLD_RED}WARNING: Failed to fetch models from LLM proxy. Using static fallback (ai-models.json).{RESET}")
+        logger.warning("Failed to fetch models from LLM proxy. Using static fallback (ai-models.json).")
+
+# ---------------------------------------------------------------------------
+# Startup fallback walk: heal AI_MODEL if it was filtered out / absent
+# ---------------------------------------------------------------------------
+
+def _resolve_startup_model():
+    """Walk AI_MODEL_FALLBACKS at startup if the configured AI_MODEL is not in
+    AVAILABLE_MODELS. Logs loudly which model wins. Updates DEFAULT_AI_CONFIG in place.
+    """
+    if AI_MODE != 'relay':
+        return  # no relay, no model to validate
+
+    all_model_ids = [mid for pm in AVAILABLE_MODELS.values() for mid in pm]
+    current = DEFAULT_AI_CONFIG['model']
+
+    if current in all_model_ids:
+        return  # happy path
+
+    logger.warning(f"AI_MODEL '{current}' is absent from the filtered model list.")
+    for candidate in AI_MODEL_FALLBACKS:
+        if candidate in all_model_ids:
+            logger.warning(f"AI startup fallback: '{current}' not available; using '{candidate}' instead.")
+            DEFAULT_AI_CONFIG['model'] = candidate
+            return
+
+    if all_model_ids:
+        winner = all_model_ids[0]
+        logger.warning(f"AI startup fallback: no fallback matched; using first available model '{winner}'.")
+        DEFAULT_AI_CONFIG['model'] = winner
+    else:
+        logger.error(f"AI startup fallback: no models available at all — relay will 400 on every request.")
+
+
+_resolve_startup_model()
 
 # Default prompt templates - configurable via environment
 DEFAULT_SYSTEM_PROMPT = os.environ.get('AI_SYSTEM_PROMPT', '''You are DocCode's Kroki diagram assistant. Respond with ONLY a JSON object — no prose, no markdown, no code fences — exactly:
@@ -306,17 +425,17 @@ Renderer error:
 
 @app.route('/api/ai-prompts', methods=['GET'])
 def get_ai_prompts():
-    """Get default AI prompt templates"""
+    """Get default AI prompt templates — un-gated in all modes (BYOK clients need it)"""
     try:
         if not validate_origin(request):
             return jsonify({'error': 'Unauthorized origin'}), 403
-        
+
         return jsonify({
             'system': DEFAULT_SYSTEM_PROMPT,
             'user': DEFAULT_USER_PROMPT,
             'retry': DEFAULT_RETRY_PROMPT
         })
-    
+
     except Exception as e:
         logger.error(f"Error getting AI prompts: {str(e)}")
         return jsonify({'error': 'Internal server error'}), 500
@@ -327,15 +446,25 @@ def get_available_models():
     try:
         if not validate_origin(request):
             return jsonify({'error': 'Unauthorized origin'}), 403
-        
-        # Return all models from JSON file (no filtering)
+
+        if AI_MODE != 'relay':
+            # Do not leak proxy URL or name in non-relay modes
+            return jsonify({
+                'mode': AI_MODE,
+                'models': {},
+                'proxy_url': None,
+                'proxy_name': None,
+                'default_model': None,
+            })
+
         return jsonify({
+            'mode': 'relay',
             'models': AVAILABLE_MODELS,
             'proxy_url': AI_PROXY_URL,
             'proxy_name': AI_PROXY_NAME,
             'default_model': DEFAULT_AI_CONFIG['model']
         })
-    
+
     except Exception as e:
         logger.error(f"Error getting available models: {str(e)}")
         return jsonify({'error': 'Internal server error'}), 500
@@ -346,18 +475,18 @@ def validate_model():
     try:
         if not validate_origin(request):
             return jsonify({'error': 'Unauthorized origin'}), 403
-        
+
         data = request.get_json()
         model_name = data.get('model')
-        
+
         if not model_name:
             return jsonify({'error': 'Model name is required'}), 400
-        
+
         # Build a flat list of all allowed models from the JSON configuration
         allowed_models = {}
         for provider_models in AVAILABLE_MODELS.values():
             allowed_models.update(provider_models)
-        
+
         # Check if the requested model is in our allowed list
         if model_name not in allowed_models:
             logger.warning(f"Model validation failed for '{model_name}' - not in allowed models list. Request from: {request.remote_addr}")
@@ -365,17 +494,17 @@ def validate_model():
                 'valid': False,
                 'error': f'Model "{model_name}" is not supported. Please select from available models.'
             }), 400
-        
+
         model_info = allowed_models[model_name]
         logger.info(f"Model validation successful for '{model_name}'")
-        
+
         # Return model as valid since it's in the JSON (no proxy validation)
         return jsonify({
             'valid': True,
             'model_info': model_info,
             'note': 'Model found in configuration - validation at deployment time'
         })
-    
+
     except Exception as e:
         logger.error(f"Error validating model: {str(e)}")
         return jsonify({'error': 'Internal server error'}), 500
@@ -436,12 +565,25 @@ def authorize_ai_request(request):
         return hmac.compare_digest(presented, AI_ACCESS_TOKEN)
     return validate_session_token(request.cookies.get(SESSION_COOKIE_NAME, ''))
 
+
 @app.errorhandler(429)
 def ratelimit_handler(e):
+    # Distinguish per-IP quota trips from generic rate limits
+    description = str(getattr(e, 'description', '') or '')
+    if 'per_ip_quota' in description or (AI_DAILY_LIMIT_PER_IP and 'day' in description.lower()):
+        return jsonify({'error': PER_IP_COPY, 'code': 'per_ip_quota'}), 429
     return jsonify({'error': 'Rate limit exceeded. Please wait before sending another request.'}), 429
+
+
+def _per_ip_limit():
+    """Return the per-IP daily limit string, or a harmless fallback."""
+    return AI_DAILY_LIMIT_PER_IP or '1000000/day'
+
 
 @app.route('/api/ai-assist', methods=['POST'])
 @limiter.limit("10/minute")
+@limiter.limit(_per_ip_limit, error_message='per_ip_quota',
+               exempt_when=lambda: not AI_DAILY_LIMIT_PER_IP)
 def ai_assist():
     """AI Assistant API proxy endpoint"""
     try:
@@ -451,26 +593,38 @@ def ai_assist():
         if not validate_origin(request, require=True):
             return jsonify({'error': 'Unauthorized origin'}), 403
 
+        # Mode gate: must be relay before auth (503 exposes mode to the client
+        # so the frontend can guide BYOK instead of chasing a phantom auth error).
+        if AI_MODE != 'relay':
+            return jsonify({
+                'error': ('The AI relay is disabled on this server. Add your own '
+                          'OpenAI-compatible endpoint and API key in Settings → AI Assistant.'),
+                'mode': AI_MODE,
+            }), 503
+
         if not authorize_ai_request(request):
             return jsonify({'error': 'Unauthorized. Please reload the page and try again.'}), 401
 
-        if not DEFAULT_AI_CONFIG['enabled']:
-            return jsonify({'error': 'AI Assistant is disabled'}), 503
-        
         # Check request size
         if request.content_length and request.content_length > MAX_REQUEST_SIZE:
             return jsonify({'error': 'Request too large'}), 413
-        
+
         # Parse request data
         try:
             data = request.get_json(force=True)
         except Exception as e:
             logger.error(f"Invalid JSON in request: {e}")
             return jsonify({'error': 'Invalid JSON'}), 400
-        
+
+        # H6: Belt-and-suspenders — pop client-supplied key/endpoint so they
+        # can never appear in any log entry, even if logging expands later.
+        if isinstance(data, dict) and isinstance(data.get('config'), dict):
+            data['config'].pop('api_key', None)
+            data['config'].pop('endpoint', None)
+
         if not data or 'messages' not in data:
             return jsonify({'error': 'Missing messages in request'}), 400
-        
+
         # Extract configuration from request or use defaults
         config = data.get('config', {})
         model = data.get('model', DEFAULT_AI_CONFIG['model'])  # Get model from top-level, not from config
@@ -482,26 +636,26 @@ def ai_assist():
         except (TypeError, ValueError):
             return jsonify({'error': 'Invalid timeout value'}), 400
         timeout = max(1, min(timeout, AI_TIMEOUT_MAX))
-        
+
         # Validate model against allowed models from JSON to prevent model injection
         if model:
             # Build a flat list of all allowed models from the JSON configuration
             allowed_models = []
             for provider_models in AVAILABLE_MODELS.values():
                 allowed_models.extend(provider_models.keys())
-            
+
             # Check if the requested model is in our allowed list
             if model not in allowed_models:
                 logger.warning(f"Model injection attempt detected: '{model}' not in allowed models list. Request from: {request.remote_addr}")
                 return jsonify({'error': f'Model "{model}" is not supported. Please select from available models.'}), 400
-            
+
             logger.info(f"Validated model '{model}' against allowed models list")
         else:
             # If no model provided, use default (which should also be validated)
             if DEFAULT_AI_CONFIG['model'] not in [model_id for provider_models in AVAILABLE_MODELS.values() for model_id in provider_models.keys()]:
                 logger.error(f"Default model '{DEFAULT_AI_CONFIG['model']}' is not in allowed models list")
                 return jsonify({'error': 'Server configuration error: default model not supported'}), 500
-        
+
         # This endpoint ONLY ever proxies to the trusted, server-configured AI
         # proxy. Direct/custom API endpoints are handled entirely client-side, so
         # /api/ai-assist cannot be used as an SSRF / open relay to arbitrary URLs.
@@ -512,15 +666,15 @@ def ai_assist():
             return jsonify({'error': 'Backend proxy API key not configured'}), 400
 
         logger.info(f"Using backend proxy: {endpoint}")
-        
+
         headers = {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {api_key}'
         }
-        
+
         # Build payload with provider-specific parameter handling
         ai_payload = build_ai_payload(model, data['messages'], data)
-        
+
         logger.info(f"Proxying AI request to {endpoint} with model {model}")
 
         # Handle streaming responses
@@ -537,12 +691,27 @@ def ai_assist():
 
             if resp.status_code != 200:
                 error_msg = f"AI API error: {resp.status_code}"
+                retry_after = None
                 try:
                     error_data = resp.json()
                     if 'error' in error_data:
                         error_msg = error_data['error'].get('message', error_msg)
-                except:
+                    # Extract retry_after from metadata headers
+                    meta = error_data.get('error', {}).get('metadata', {})
+                    hdrs = meta.get('headers', {})
+                    retry_after = hdrs.get('X-RateLimit-Reset') or resp.headers.get('Retry-After')
+                except Exception:
                     error_msg = resp.text or error_msg
+
+                # Map upstream quota errors to a client-visible quota state
+                if resp.status_code in (429, 402):
+                    logger.warning(f"Upstream quota/billing error {resp.status_code}: {error_msg}")
+                    return jsonify({
+                        'error': FREE_QUOTA_COPY,
+                        'code': 'free_quota_exhausted',
+                        'retry_after': retry_after,
+                    }), 429
+
                 logger.error(f"AI API streaming error: {error_msg}")
                 return jsonify({'error': error_msg}), resp.status_code
 
@@ -582,25 +751,43 @@ def ai_assist():
             ai_response = response.json()
             return jsonify(ai_response)
         else:
+            # Map upstream quota errors to a client-visible quota state
+            if response.status_code in (429, 402):
+                retry_after = None
+                try:
+                    error_data = response.json()
+                    meta = error_data.get('error', {}).get('metadata', {})
+                    hdrs = meta.get('headers', {})
+                    retry_after = hdrs.get('X-RateLimit-Reset') or response.headers.get('Retry-After')
+                    error_msg = error_data.get('error', {}).get('message', '')
+                except Exception:
+                    error_msg = response.text or ''
+                logger.warning(f"Upstream quota/billing error {response.status_code}: {error_msg}")
+                return jsonify({
+                    'error': FREE_QUOTA_COPY,
+                    'code': 'free_quota_exhausted',
+                    'retry_after': retry_after,
+                }), 429
+
             error_msg = f"AI API error: {response.status_code}"
             try:
                 error_data = response.json()
                 if 'error' in error_data:
                     error_msg = error_data['error'].get('message', error_msg)
-            except:
+            except Exception:
                 error_msg = response.text or error_msg
 
             logger.error(f"AI API error: {error_msg}")
             return jsonify({'error': error_msg}), response.status_code
-    
+
     except requests.exceptions.Timeout:
         logger.error("AI API request timeout")
         return jsonify({'error': 'Request timeout'}), 504
-    
+
     except requests.exceptions.ConnectionError:
         logger.error("Failed to connect to AI API")
         return jsonify({'error': 'Failed to connect to AI service'}), 503
-    
+
     except Exception as e:
         logger.error(f"Unexpected error in AI assist: {e}")
         return jsonify({'error': 'Internal server error'}), 500
@@ -610,9 +797,10 @@ def get_config():
     """Get server AI and Draw.io configuration (without sensitive data)"""
     config = {
         'ai': {
-            'enabled': DEFAULT_AI_CONFIG['enabled'],
-            'has_api_key': bool(DEFAULT_AI_CONFIG['api_key']),
-            'model': DEFAULT_AI_CONFIG['model'],
+            'enabled': AI_MODE == 'relay',  # back-compat: true only in relay mode
+            'mode': AI_MODE,
+            'has_api_key': AI_MODE == 'relay' and bool(DEFAULT_AI_CONFIG['api_key']),
+            'model': DEFAULT_AI_CONFIG['model'] if AI_MODE == 'relay' else None,
             'timeout': DEFAULT_AI_CONFIG['timeout']
         },
         'drawio': {
@@ -630,7 +818,8 @@ def health_check():
     return jsonify({
         'status': 'healthy',
         'timestamp': datetime.utcnow().isoformat(),
-        'ai_enabled': DEFAULT_AI_CONFIG['enabled']
+        'ai_enabled': AI_MODE == 'relay',
+        'ai_mode': AI_MODE,
     })
 
 @app.route('/api/version', methods=['GET'])
@@ -639,7 +828,7 @@ def get_version():
     try:
         if not validate_origin(request):
             return jsonify({'error': 'Unauthorized origin'}), 403
-        
+
         return jsonify({
             'version': os.environ.get('VERSION', '1.0.0'),
             'name': 'DocCode - The Kroki Server Frontend',
@@ -659,8 +848,9 @@ def get_version():
                 'hostname': HOSTNAME,
                 'port': PORT,
                 'https_port': HTTPS_PORT,
-                'ai_enabled': DEFAULT_AI_CONFIG['enabled'],
-                'ai_model': DEFAULT_AI_CONFIG['model'] if DEFAULT_AI_CONFIG['enabled'] else None
+                'ai_enabled': AI_MODE == 'relay',
+                'ai_mode': AI_MODE,
+                'ai_model': DEFAULT_AI_CONFIG['model'] if AI_MODE == 'relay' else None
             }
         })
     except Exception as e:
@@ -722,9 +912,13 @@ if __name__ == '__main__':
     # CMD); do not use this path in production.
     logger.info(f"Starting Kroki Demo Site Server on port {PORT}")
     logger.info(f"Static files served from: {STATIC_ROOT}")
-    logger.info(f"AI Assistant enabled: {DEFAULT_AI_CONFIG['enabled']}")
+    logger.info(f"AI mode: {AI_MODE} (enabled={DEFAULT_AI_CONFIG['enabled']}, has_key={bool(AI_PROXY_API_KEY)})")
     model_count = sum(len(models) for models in AVAILABLE_MODELS.values())
     logger.info(f"Available AI models: {model_count} across {len(AVAILABLE_MODELS)} providers")
+    if AI_MODEL_ALLOWLIST:
+        logger.info(f"AI model allowlist active: {AI_MODEL_ALLOWLIST}")
+    if AI_DAILY_LIMIT_PER_IP:
+        logger.info(f"Per-IP AI daily limit: {AI_DAILY_LIMIT_PER_IP}")
 
     # Run the Flask app
     app.run(

--- a/demoSite/tests/byokKey.test.js
+++ b/demoSite/tests/byokKey.test.js
@@ -1,0 +1,376 @@
+/**
+ * BYOK key-lifecycle regression tests (§3.6, tests 1–7).
+ *
+ * These tests lock the guarantee:
+ *   "Your API key is stored only in this browser. In custom-API mode, requests
+ *    go directly from your browser to the endpoint you configure; the key is
+ *    never included in any request to this site."
+ *
+ * Run with: bun test tests/byokKey.test.js
+ */
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Browser-environment stubs (Bun runs in Node; simulate just enough of the
+// browser globals that the modules under test need).
+// ---------------------------------------------------------------------------
+
+// Minimal localStorage
+const _store = {};
+globalThis.localStorage = {
+    getItem:    (k) => (k in _store ? _store[k] : null),
+    setItem:    (k, v) => { _store[k] = String(v); },
+    removeItem: (k) => { delete _store[k]; },
+};
+
+// window = globalThis in this environment
+globalThis.window = globalThis;
+
+// Stubs consumed by config.js
+globalThis.inputValidation = null;   // triggers the safe null-check in set()
+
+// APP_CONSTANTS used by ai-assistant-api.js
+globalThis.APP_CONSTANTS = { AI_MAX_TOKENS: 16000, AI_TEMPERATURE: 0.7 };
+
+// ---------------------------------------------------------------------------
+// Import modules under test
+// ---------------------------------------------------------------------------
+
+// config.js exports ConfigManager; also sets window.configManager
+const { ConfigManager } = await import('../js/config.js');
+
+// ai-assistant-api.js sets window.AIAssistantAPI
+await import('../js/ai-assistant-api.js');
+
+// ai-assistant-prompts.js (needed by validateModel's error path)
+// stub it minimally
+globalThis.AIAssistantPrompts = {
+    getDefaultSystemPrompt: () => '',
+    getDefaultUserPrompt:   () => '',
+    getDefaultRetryPrompt:  () => '',
+};
+
+// dom.js (used by addMessage indirectly) — not needed for these unit tests
+// ai-assistant-ui.js — not needed for these unit tests
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal fetch mock that resolves once with the given response,
+ * recording every call into `calls`.
+ */
+function makeFetchMock(responseFactory) {
+    const calls = [];
+    const mock = async (url, init = {}) => {
+        const body = init.body;
+        calls.push({ url, headers: init.headers || {}, body, parsedBody: body ? (() => { try { return JSON.parse(body); } catch { return null; } })() : null });
+        return responseFactory(url, init);
+    };
+    mock.calls = calls;
+    return mock;
+}
+
+/** Minimal SSE-ish streaming response */
+function makeStreamingOkResponse(text = 'data: [DONE]\n') {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+        start(ctrl) {
+            ctrl.enqueue(encoder.encode(text));
+            ctrl.close();
+        }
+    });
+    return {
+        ok: true,
+        status: 200,
+        headers: { get: (h) => h === 'content-type' ? 'text/event-stream' : null },
+        body: { getReader: () => {
+            let done = false;
+            const chunks = [encoder.encode(text)];
+            let i = 0;
+            return {
+                read: async () => i < chunks.length
+                    ? { done: false, value: chunks[i++] }
+                    : { done: true, value: undefined },
+                releaseLock: () => {}
+            };
+        }},
+        json: async () => ({})
+    };
+}
+
+/** Minimal non-streaming ok response */
+function makeJsonOkResponse(data = {}) {
+    return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => data,
+    };
+}
+
+beforeEach(() => {
+    // Clear localStorage between tests
+    for (const k of Object.keys(_store)) delete _store[k];
+    // Reset fetch
+    globalThis.fetch = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: callCustomAPI fetches ONLY the configured endpoint with the key
+// ---------------------------------------------------------------------------
+
+test('T1: callCustomAPI fetches only the user endpoint with Authorization: Bearer', async () => {
+    const customEndpoint = 'https://api.example.com/v1/chat/completions';
+    const fetchMock = makeFetchMock(() => makeStreamingOkResponse());
+    globalThis.fetch = fetchMock;
+
+    const config = {
+        endpoint: customEndpoint,
+        apiKey: 'sk-TEST',
+        model: 'gpt-4o-mini',
+        customModel: '',
+        timeout: 30,
+    };
+
+    const callbacks = {
+        addStreamingMessage: () => null,
+        updateStreamingMessage: () => {},
+        scrollToBottom: () => {},
+    };
+
+    await window.AIAssistantAPI.callCustomAPI(
+        [{ role: 'user', content: 'hello' }],
+        config,
+        null,
+        callbacks
+    );
+
+    assert.equal(fetchMock.calls.length, 1, 'exactly one fetch call');
+    const call = fetchMock.calls[0];
+    assert.equal(call.url, customEndpoint, 'fetches the configured endpoint');
+    assert.equal(call.headers['Authorization'], 'Bearer sk-TEST', 'Authorization header set correctly');
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: callCustomAPI never hits the app origin / /api/ai-assist
+// ---------------------------------------------------------------------------
+
+test('T2: callCustomAPI never targets the app origin', async () => {
+    const fetchMock = makeFetchMock(() => makeStreamingOkResponse());
+    globalThis.fetch = fetchMock;
+
+    const config = {
+        endpoint: 'https://api.example.com/v1/chat/completions',
+        apiKey: 'sk-TEST',
+        model: 'gpt-4o-mini',
+        customModel: '',
+        timeout: 30,
+    };
+
+    const callbacks = {
+        addStreamingMessage: () => null,
+        updateStreamingMessage: () => {},
+        scrollToBottom: () => {},
+    };
+
+    await window.AIAssistantAPI.callCustomAPI(
+        [{ role: 'user', content: 'hello' }],
+        config,
+        null,
+        callbacks
+    );
+
+    for (const call of fetchMock.calls) {
+        // Must not hit a relative URL or the local /api/ai-assist path
+        assert.ok(
+            !call.url.startsWith('/api/') && !call.url.includes('/api/ai-assist'),
+            `callCustomAPI must not target app origin, got: ${call.url}`
+        );
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 (H1 regression sentinel): callProxyAPI body contains NO api_key,
+// NO endpoint, and does NOT contain the test key string
+// ---------------------------------------------------------------------------
+
+test('T3 (H1): callProxyAPI body contains no api_key, no endpoint, not the key string', async () => {
+    const fetchMock = makeFetchMock(() => makeStreamingOkResponse());
+    globalThis.fetch = fetchMock;
+
+    const config = {
+        useCustomAPI: false,   // proxy mode — H1 guard must not fire
+        apiKey: '',            // no key in proxy mode
+        endpoint: '',
+        model: 'openai/gpt-5-mini',
+        customModel: '',
+        maxRetryAttempts: 3,
+        timeout: 30,
+    };
+
+    const callbacks = {
+        addStreamingMessage: () => null,
+        updateStreamingMessage: () => {},
+        scrollToBottom: () => {},
+    };
+
+    // Set a fake location origin so the Origin header is populated
+    globalThis.location = { origin: 'https://localhost:8443' };
+
+    await window.AIAssistantAPI.callProxyAPI(
+        [{ role: 'user', content: 'hello' }],
+        config,
+        null,
+        callbacks
+    );
+
+    assert.equal(fetchMock.calls.length, 1, 'exactly one fetch call');
+    const call = fetchMock.calls[0];
+    const body = call.parsedBody;
+
+    assert.ok(body, 'body must be JSON-parseable');
+    // The config object in the body must not carry api_key or endpoint
+    const bodyConfig = body.config || {};
+    assert.equal(bodyConfig.api_key, undefined, 'api_key must be absent from proxy body');
+    assert.equal(bodyConfig.endpoint, undefined, 'endpoint must be absent from proxy body');
+    // The serialized body must not contain any key-like string
+    assert.ok(
+        !call.body.includes('sk-'),
+        'serialized proxy body must not contain any sk- key string'
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: mode selector stays on custom under retry (no fallback to proxy)
+// ---------------------------------------------------------------------------
+
+test('T4: selector stays on callCustomAPI under retry — no fallback to callProxyAPI', async () => {
+    let callCount = 0;
+    const fetchMock = makeFetchMock(() => {
+        callCount++;
+        if (callCount === 1) {
+            // First call: reject to simulate a network error
+            return Promise.reject(new Error('Network error'));
+        }
+        return makeStreamingOkResponse();
+    });
+    globalThis.fetch = fetchMock;
+    globalThis.location = { origin: 'https://localhost:8443' };
+
+    const config = {
+        endpoint: 'https://api.example.com/v1/chat/completions',
+        apiKey: 'sk-RETRY-TEST',
+        model: 'gpt-4o-mini',
+        customModel: '',
+        timeout: 5,
+    };
+
+    const callbacks = {
+        addStreamingMessage: () => null,
+        updateStreamingMessage: () => {},
+        scrollToBottom: () => {},
+    };
+
+    // First call will throw; callCustomAPI itself does not retry (retries are
+    // driven by makeAIRequest in ai-assistant.js). Verify the fetch mock was
+    // called with the custom endpoint, not /api/ai-assist.
+    try {
+        await window.AIAssistantAPI.callCustomAPI(
+            [{ role: 'user', content: 'hello' }],
+            config,
+            null,
+            callbacks
+        );
+    } catch {
+        // expected on first call
+    }
+
+    for (const call of fetchMock.calls) {
+        assert.equal(call.url, config.endpoint,
+            `all fetch calls must target the custom endpoint, got: ${call.url}`);
+        assert.ok(!call.url.includes('/api/ai-assist'),
+            'must never fall back to /api/ai-assist');
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: configManager.export() strips the api key
+// ---------------------------------------------------------------------------
+
+test('T5: export() strips the api key', () => {
+    const cm = new ConfigManager();
+    cm.set('ai.apiKey', 'sk-SECRET');
+    const exported = JSON.parse(cm.export());
+    assert.equal(exported.ai.apiKey, '',
+        'export() must strip ai.apiKey (config.js:427-429)');
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: chatHistory / getConversationHistory never contains the key
+// ---------------------------------------------------------------------------
+
+test('T6: chatHistory entries have only type/text — no key metadata', () => {
+    // Simulate what AIAssistant.addMessage pushes into chatHistory
+    const chatHistory = [];
+    const addMessage = (type, text) => {
+        chatHistory.push({ type, text, timestamp: new Date() });
+    };
+
+    addMessage('user', 'draw a sequence diagram');
+    addMessage('assistant', '{"diagramCode":"...","explanation":"Done"}');
+
+    // Simulate getConversationHistory filter
+    const history = chatHistory.filter(m =>
+        m.type === 'user' || m.type.startsWith('assistant')
+    );
+
+    const serialized = JSON.stringify(history);
+    assert.ok(!serialized.includes('sk-'), 'no key string in conversation history');
+    assert.ok(!serialized.includes('apiKey'), 'no apiKey field in conversation history');
+    assert.ok(!serialized.includes('endpoint'), 'no endpoint field in conversation history');
+
+    // Each entry should have only type + text (+ timestamp, which is harmless)
+    for (const entry of history) {
+        assert.ok('type' in entry, 'entry has type');
+        assert.ok('text' in entry, 'entry has text');
+        assert.ok(!('apiKey' in entry), 'entry must not have apiKey');
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Test 7 (H2): XSS payload in customModel is escaped in the model-unavailable
+// system message; window.__pwned must remain undefined
+// ---------------------------------------------------------------------------
+
+test('T7 (H2): XSS payload in customModel is entity-escaped before innerHTML injection', () => {
+    // The escape helper from ai-assistant.js (reproduced inline for unit isolation)
+    const esc = s => String(s).replace(/[&<>"']/g, c =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+    const maliciousModel = '<img src=x onerror="globalThis.__pwned=1">';
+    const escaped = esc(maliciousModel);
+
+    // Build the message the same way ai-assistant.js does (post-H2)
+    const message = `Model "${escaped}" is not available. Please open settings to select a different model.`;
+
+    // Simulate innerHTML assignment in a minimal DOM-like env
+    // (Bun has no DOM; test the string content instead)
+    assert.ok(!message.includes('<img'), 'raw <img> tag must not appear in message');
+    assert.ok(!message.includes('<script'), 'raw <script> tag must not appear in message');
+    assert.ok(message.includes('&lt;img'), 'must contain HTML-escaped version');
+    assert.ok(message.includes('onerror='), 'onerror attribute text is present but inert (escaped context)');
+
+    // The escape helper itself must handle all five dangerous chars
+    assert.equal(esc('<'), '&lt;');
+    assert.equal(esc('>'), '&gt;');
+    assert.equal(esc('"'), '&quot;');
+    assert.equal(esc("'"), '&#39;');
+    assert.equal(esc('&'), '&amp;');
+
+    // globalThis.__pwned must not have been set (no script execution)
+    assert.equal(globalThis.__pwned, undefined, 'XSS payload must not execute');
+});

--- a/demoSite/tests/conftest.py
+++ b/demoSite/tests/conftest.py
@@ -18,6 +18,10 @@ os.environ.setdefault('AI_PROXY_API_KEY', 'test-proxy-key')
 os.environ.setdefault('AI_MODEL', 'openai/gpt-5-mini')
 os.environ.setdefault('SESSION_SECRET', 'test-session-secret')
 os.environ.pop('AI_ACCESS_TOKEN', None)
+# Ensure new AI-posture vars don't bleed in from the shell environment
+os.environ.pop('AI_MODEL_ALLOWLIST', None)
+os.environ.pop('AI_MODEL_FALLBACKS', None)
+os.environ.pop('AI_DAILY_LIMIT_PER_IP', None)
 
 import pytest
 

--- a/demoSite/tests/test_server.py
+++ b/demoSite/tests/test_server.py
@@ -191,3 +191,236 @@ def test_requirements_not_served(client):
 def test_regular_static_files_still_served(client):
     resp = client.get('/js/main.js')
     assert resp.status_code == 200
+
+
+# --- AI mode: compute_ai_mode matrix -------------------------------------------
+
+
+def test_compute_ai_mode_relay(server):
+    assert server.compute_ai_mode(True, True) == 'relay'
+
+
+def test_compute_ai_mode_byok_no_key(server):
+    assert server.compute_ai_mode(True, False) == 'byok'
+
+
+def test_compute_ai_mode_off(server):
+    assert server.compute_ai_mode(False, True) == 'off'
+    assert server.compute_ai_mode(False, False) == 'off'
+
+
+# --- mode gate (byok/off → 503 before auth) ------------------------------------
+
+
+def test_byok_mode_returns_503_before_auth(client, server, upstream, monkeypatch):
+    """Mode gate must fire BEFORE authorize_ai_request (503 beats 401)."""
+    monkeypatch.setattr(server, 'AI_MODE', 'byok')
+    resp = post_ai(client, with_session=False)
+    assert resp.status_code == 503
+    data = resp.get_json()
+    assert data['mode'] == 'byok'
+    assert upstream.calls == []
+
+
+def test_off_mode_returns_503(client, server, upstream, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'off')
+    resp = post_ai(client)
+    assert resp.status_code == 503
+    assert upstream.calls == []
+
+
+def test_relay_mode_still_proxies(client, server, upstream, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    resp = post_ai(client)
+    assert resp.status_code == 200
+    assert len(upstream.calls) == 1
+
+
+# --- /api/config advertises mode -----------------------------------------------
+
+
+def test_config_advertises_relay_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    ai = client.get('/api/config').get_json()['ai']
+    assert ai['mode'] == 'relay'
+    assert ai['enabled'] is True
+
+
+def test_config_advertises_byok_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'byok')
+    ai = client.get('/api/config').get_json()['ai']
+    assert ai['mode'] == 'byok'
+    assert ai['enabled'] is False
+    assert ai['model'] is None
+
+
+def test_config_advertises_off_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'off')
+    ai = client.get('/api/config').get_json()['ai']
+    assert ai['mode'] == 'off'
+    assert ai['enabled'] is False
+
+
+# --- /api/available-models hides proxy in non-relay modes ----------------------
+
+
+def test_available_models_relay_returns_models(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    data = client.get('/api/available-models', headers={'Origin': GOOD_ORIGIN}).get_json()
+    assert data['mode'] == 'relay'
+    assert data['proxy_url'] is not None
+
+
+def test_available_models_byok_hides_proxy(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'byok')
+    data = client.get('/api/available-models', headers={'Origin': GOOD_ORIGIN}).get_json()
+    assert data['models'] == {}
+    assert data['proxy_url'] is None
+    assert data['proxy_name'] is None
+
+
+def test_available_models_off_hides_proxy(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'off')
+    data = client.get('/api/available-models', headers={'Origin': GOOD_ORIGIN}).get_json()
+    assert data['models'] == {}
+    assert data['proxy_url'] is None
+
+
+# --- /api/health and /api/version expose ai_mode -------------------------------
+
+
+def test_health_exposes_ai_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'byok')
+    data = client.get('/api/health').get_json()
+    assert data['ai_mode'] == 'byok'
+    assert data['ai_enabled'] is False
+
+
+def test_version_exposes_ai_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    data = client.get('/api/version', headers={'Origin': GOOD_ORIGIN}).get_json()
+    assert data['server_info']['ai_mode'] == 'relay'
+    assert data['server_info']['ai_enabled'] is True
+
+
+# --- allowlist filter ----------------------------------------------------------
+
+
+def test_apply_model_allowlist_empty_allows_all(server):
+    original = server.AI_MODEL_ALLOWLIST
+    try:
+        server.AI_MODEL_ALLOWLIST = []
+        grouped = {'openai': {'openai/gpt-4o': {}, 'openai/gpt-4o-mini': {}}}
+        result = server.apply_model_allowlist(grouped)
+        assert 'openai' in result
+        assert len(result['openai']) == 2
+    finally:
+        server.AI_MODEL_ALLOWLIST = original
+
+
+def test_apply_model_allowlist_glob_filters(server):
+    original = server.AI_MODEL_ALLOWLIST
+    try:
+        server.AI_MODEL_ALLOWLIST = ['*:free']
+        grouped = {
+            'openai': {'openai/gpt-4o': {}, 'openai/gpt-4o:free': {}},
+            'meta': {'meta-llama/llama-3.3-70b:free': {}},
+        }
+        result = server.apply_model_allowlist(grouped)
+        # paid model must be filtered out
+        assert 'openai/gpt-4o' not in result.get('openai', {})
+        assert 'openai/gpt-4o:free' in result['openai']
+        assert 'meta-llama/llama-3.3-70b:free' in result['meta']
+    finally:
+        server.AI_MODEL_ALLOWLIST = original
+
+
+def test_allowlist_enforced_on_relay_request(client, server, upstream, monkeypatch):
+    """A non-allowlisted model POST must 400 before reaching upstream."""
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    monkeypatch.setattr(server, 'AVAILABLE_MODELS', {'openai': {MODEL: {}}})
+    # allowed model succeeds
+    resp = post_ai(client, body=ai_body(model=MODEL))
+    assert resp.status_code == 200
+    assert len(upstream.calls) == 1
+    # disallowed model is rejected before upstream
+    resp2 = post_ai(client, body=ai_body(model='openai/gpt-4o'))
+    assert resp2.status_code == 400
+    assert len(upstream.calls) == 1  # no new upstream call
+
+
+# --- /api/ai-prompts is ungated in byok mode -----------------------------------
+
+
+def test_ai_prompts_returns_200_in_byok_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'byok')
+    resp = client.get('/api/ai-prompts', headers={'Origin': GOOD_ORIGIN})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'system' in data
+
+
+def test_ai_prompts_returns_200_in_relay_mode(client, server, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    resp = client.get('/api/ai-prompts', headers={'Origin': GOOD_ORIGIN})
+    assert resp.status_code == 200
+
+
+# --- upstream quota mapping (429/402 → free_quota_exhausted) ------------------
+
+
+def test_upstream_429_maps_to_free_quota_exhausted(client, server, upstream, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    upstream.response = server.tests_conftest_FakeUpstreamResponse_429() if hasattr(server, 'tests_conftest_FakeUpstreamResponse_429') else None
+    # Use the fixture's response object directly
+    from conftest import FakeUpstreamResponse
+    upstream.response = FakeUpstreamResponse(
+        status_code=429,
+        json_body={'error': {'message': 'Rate limit exceeded', 'code': 429, 'metadata': {'headers': {}}}},
+    )
+    resp = post_ai(client)
+    assert resp.status_code == 429
+    data = resp.get_json()
+    assert data['code'] == 'free_quota_exhausted'
+
+
+def test_upstream_402_maps_to_free_quota_exhausted(client, server, upstream, monkeypatch):
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    from conftest import FakeUpstreamResponse
+    upstream.response = FakeUpstreamResponse(
+        status_code=402,
+        json_body={'error': {'message': 'Insufficient credits', 'code': 402}},
+    )
+    resp = post_ai(client)
+    assert resp.status_code == 429
+    data = resp.get_json()
+    assert data['code'] == 'free_quota_exhausted'
+
+
+# --- H6: server pops client-supplied api_key/endpoint before any logging -------
+
+
+def test_server_ignores_client_api_key_and_uses_server_key(client, server, upstream, monkeypatch):
+    """Client-supplied key must never reach the upstream call (server forces its own)."""
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    body = ai_body()
+    body['config'] = {'api_key': 'sk-CLIENT', 'endpoint': 'https://evil.example/', 'timeout': 30}
+    resp = post_ai(client, body=body)
+    assert resp.status_code == 200
+    call = upstream.calls[0]
+    # Server must use its own key, not the client's
+    auth_header = call['headers']['Authorization']
+    assert 'sk-CLIENT' not in auth_header
+    assert 'evil.example' not in call['url']
+
+
+def test_server_does_not_log_canary_key(client, server, upstream, monkeypatch, caplog):
+    """sk-CANARY must not appear in any log record (H6 + never-logged guarantee)."""
+    import logging
+    monkeypatch.setattr(server, 'AI_MODE', 'relay')
+    body = ai_body()
+    body['config'] = {'api_key': 'sk-CANARY', 'timeout': 30}
+    with caplog.at_level(logging.DEBUG):
+        post_ai(client, body=body)
+    for record in caplog.records:
+        assert 'sk-CANARY' not in record.getMessage()

--- a/docs/byok-privacy.md
+++ b/docs/byok-privacy.md
@@ -1,0 +1,67 @@
+# BYOK Key Privacy Guarantee
+
+This document explains exactly what happens to your API key when you use the
+"Use Direct API" (Bring Your Own Key) mode in DocCode, and how you can verify
+the guarantee yourself.
+
+## The guarantee
+
+> Your API key is stored only in this browser (localStorage). In custom-API
+> mode, requests go directly from your browser to the endpoint you configure.
+> The key is never included in any request to the DocCode server, never
+> received by the DocCode backend, and never logged. This is structurally
+> enforced in code, locked by regression tests, and verifiable yourself in
+> DevTools.
+
+## How it works, code pointer by code pointer
+
+| What | Where |
+|---|---|
+| Mode selector: routes to `callCustomAPI` when `useCustomAPI && endpoint && apiKey` | `demoSite/js/ai-assistant.js:587` |
+| Direct send: key goes only to `config.endpoint` as `Authorization: Bearer` | `demoSite/js/ai-assistant-api.js:24-45` |
+| H1 structural guard: proxy request body never includes `api_key` or `endpoint`; hard assert at top of `callProxyAPI` throws if custom mode leaks in | `demoSite/js/ai-assistant-api.js:80-84` |
+| Server forces its own key: ignores any client-supplied key/endpoint; H6 pops them before any code path that could log | `demoSite/server.py` — `api_key = AI_PROXY_API_KEY` and H6 pop |
+| Export strips the key | `demoSite/js/config.js:427-429` |
+| Key stored in localStorage under `kroki-user-config` | `demoSite/js/config.js:152, 203-205` |
+
+## Verifying it yourself in DevTools
+
+1. Open DocCode in Chrome/Firefox.
+2. Open **DevTools → Network** (filter: `api`).
+3. Go to **Settings → AI Assistant**, enable "Use Direct API", enter any HTTPS
+   endpoint (e.g. `https://api.openai.com/v1/chat/completions`) and a test key
+   (e.g. `sk-test`), then click **Save**.
+4. Send a chat message.
+5. In the Network panel you will see **one** request carrying
+   `Authorization: Bearer sk-test` — it goes to **your endpoint**, not to
+   `localhost:8443` or the DocCode origin.
+6. Inspect the request to `/api/ai-assist` (if any appears — in custom mode
+   none should): confirm its body contains no `api_key` field and no `sk-`
+   string.
+
+## localStorage
+
+The key is stored **plaintext** under `kroki-user-config` in your browser's
+localStorage. It is visible to any script running on the page (which is why
+H3/H4 — Content-Security-Policy and vendored CDN bundles — matter for the
+theft-protection leg of the guarantee). The key is:
+
+- **Never exported** via the Settings → Export button (`config.js:427-429`
+  sets `ai.apiKey = ''` in the export).
+- **Never included** in shareable diagram URLs (those contain only the diagram
+  source code).
+- **Cleared** when you clear browser data or localStorage.
+
+## Regression tests that lock this guarantee
+
+| Test | What it locks |
+|---|---|
+| `byokKey.test.js` T1 | `callCustomAPI` fetches only the user endpoint with the correct `Authorization: Bearer` header |
+| `byokKey.test.js` T2 | `callCustomAPI` never targets the DocCode origin / `/api/ai-assist` |
+| `byokKey.test.js` T3 (H1 sentinel) | `callProxyAPI` body contains no `api_key`, no `endpoint`, no `sk-` string |
+| `byokKey.test.js` T4 | Mode selector stays on custom under retry — no fallback to proxy |
+| `byokKey.test.js` T5 | `configManager.export()` strips the key |
+| `byokKey.test.js` T6 | `chatHistory` / `getConversationHistory()` entries contain no key or endpoint |
+| `byokKey.test.js` T7 (H2) | XSS payload in customModel is entity-escaped; `window.__pwned` stays undefined |
+| `test_server.py` T8 | Server uses its own key, not any client-supplied key |
+| `test_server.py` T9 | `sk-CANARY` never appears in any log record at DEBUG level |


### PR DESCRIPTION
## Summary

PR-3 of the [public-hosting plan](docs/public-hosting-plan-2026-06-12.md) (§3-§4): the AI posture rework plus the verifiable BYOK key-privacy guarantee.

### Three-state AI mode
`compute_ai_mode(ai_enabled, has_proxy_key)` → `relay` (server proxies on its own key — unchanged closed-network default) | `byok` (no key configured: relay 503s with a machine-readable mode and the UI guides users to bring their own key — replaces the old request-time 400) | `off` (`AI_ENABLED=false`: assistant hidden). Mode is exposed via `/api/config`, `/api/health`, `/api/version`, and `/api/available-models` (which nulls `proxy_url`/`proxy_name` outside relay). `/api/ai-prompts` stays un-gated in byok mode (the BYOK client path depends on it) with a regression test.

### Free-tier relay support (the public-demo design)
- `AI_MODEL_ALLOWLIST` (comma-separated globs, e.g. `"*:free"`) filtered at the single point both the UI list and the relay's injection check read — they can never disagree.
- `AI_MODEL_FALLBACKS` startup self-heal for free-roster churn (walks the chain, logs the winner loudly; falls back to the first available model as a last resort).
- Upstream 429/402 → client `429 {"code":"free_quota_exhausted","retry_after":...}`; per-IP daily cap via `AI_DAILY_LIMIT_PER_IP` → `{"code":"per_ip_quota"}` — two distinct UI states with guided copy walking users into BYOK with their own free OpenRouter key.
- Default model: gpt-4o → **gpt-4o-mini** (cost-conscious default for relay self-hosters).

### BYOK privacy guarantee (audit-backed)
- **H1**: the user's key/endpoint are deleted from the proxy request body (the server always ignored them — this makes the latent leak structurally impossible) + a loud throw if the proxy path ever runs in custom mode.
- **H2**: `customModel` escaped before the `rawHtml` sink; `sanitizeString` now strips `<>`.
- **H5**: provenance note under the key field: stored only in this browser, sent only to your endpoint — never to the DocCode server.
- **H6**: server pops any client-sent `api_key`/`endpoint` before anything could log them.
- **H7**: `docs/byok-privacy.md` — the publishable guarantee with DevTools verification steps and code pointers.
- Locked by regression tests: 7 new bun tests (`byokKey.test.js`, incl. the H1 sentinel asserting the serialized proxy body carries no key) and pytest coverage incl. an `sk-CANARY` never-logged check.

## Tests
44/44 pytest (21 original unchanged + 23 new, TDD'd), 47/47 bun (40 + 7 new). Relay mode is behaviorally identical to v2.7.0 with additive fields only.

Remaining theft-surface work (CSP + vendored CDN deps) lands in PR-4; the guarantee's theft-protection clause isn't published until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)