### PR TITLE
feat(compose): companion profiles, resource limits, log rotation, graceful disabled-renderer UX (PR-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,38 @@ DRAWIO_SERVER_URL="https://embed.diagrams.net/embed"
 
 # AI prompt templates live in code defaults (server.py / ai-assistant-prompts.js).
 # To override per deployment, set AI_SYSTEM_PROMPT / AI_USER_PROMPT / AI_RETRY_PROMPT here (single line each).
+
+# --- Deployment footprint ---------------------------------------------------
+# Which optional renderers run alongside core+mermaid+demosite+nginx.
+# "companions" = bpmn + excalidraw + diagramsnet (full self-host set, default).
+# Empty (COMPOSE_PROFILES=) = trimmed public footprint (core+mermaid only),
+# saving ~4.7 GB of image pulls and ~0.5-1 GB idle RAM.
+# Granular: COMPOSE_PROFILES=bpmn  or  COMPOSE_PROFILES=bpmn,excalidraw
+# NOTE: if running docker compose directly (bypassing the setup script) with
+# a .env that predates this variable, add COMPOSE_PROFILES=companions to keep
+# the full set — the script sets this default automatically.
+COMPOSE_PROFILES=companions
+
+# Per-service resource ceilings (0 = unlimited, the default).
+# Recommended values for a public 2 vCPU / 4 GB box (uncomment all 12):
+#CORE_MEM_LIMIT=1536M
+#CORE_CPU_LIMIT=1.5
+#MERMAID_MEM_LIMIT=1024M
+#MERMAID_CPU_LIMIT=1.0
+#DEMOSITE_MEM_LIMIT=256M
+#DEMOSITE_CPU_LIMIT=0.5
+#NGINX_MEM_LIMIT=128M
+#NGINX_CPU_LIMIT=0.5
+# Only relevant when the companion profile is enabled:
+#BPMN_MEM_LIMIT=768M
+#BPMN_CPU_LIMIT=0.75
+#EXCALIDRAW_MEM_LIMIT=768M
+#EXCALIDRAW_CPU_LIMIT=0.75
+#DIAGRAMSNET_MEM_LIMIT=768M
+#DIAGRAMSNET_CPU_LIMIT=0.75
+
+# Hide diagram types whose renderers are disabled above from the editor's
+# Type dropdown (comma-separated). Match this to COMPOSE_PROFILES — e.g. for
+# the trimmed set: DISABLED_DIAGRAM_TYPES=bpmn,excalidraw,diagramsnet
+# Requires a container recreate (./setup-kroki-server.sh restart) to take effect.
+#DISABLED_DIAGRAM_TYPES=

--- a/README.md
+++ b/README.md
@@ -182,6 +182,40 @@ Users can also configure AI credentials directly in the DocCode interface throug
 - **Code Assistance**: "Fix the syntax errors in my diagram"
 - **Explanations**: "Explain what this diagram represents"
 
+## Deployment Footprint
+
+DocCode ships two footprints controlled by `COMPOSE_PROFILES` in `.env`.
+See `docs/public-hosting-plan-2026-06-12.md` for full sizing rationale.
+
+| Config | Containers | Idle RAM | Loaded RAM | Image disk |
+|---|---|---|---|---|
+| **Full set** (default) | core + mermaid + bpmn + excalidraw + diagramsnet + demosite + nginx | ~0.9–1.7 GB | 2.5–3.5 GB+ (uncapped) | ~10.2 GB |
+| **Trimmed public** | core + mermaid + demosite + nginx | ~0.4–0.8 GB | capped ~2.9 GB (sum of limits) | ~5.6 GB |
+
+### Choosing a footprint
+
+**Full set (default — no action needed for self-hosters):**
+```
+COMPOSE_PROFILES=companions   # bpmn + excalidraw + diagramsnet included
+```
+
+**Trimmed public (core + mermaid only — saves ~4.7 GB image pulls and ~0.5–1 GB idle RAM):**
+```
+COMPOSE_PROFILES=             # empty = trimmed
+DISABLED_DIAGRAM_TYPES=bpmn,excalidraw,diagramsnet   # hides them from the UI dropdown
+# Uncomment the resource-limit block in .env to cap RAM on a 4 GB box
+```
+
+After editing `.env`, apply with `./setup-kroki-server.sh restart`.
+
+> **Note for users bypassing the script:** if your `.env` predates the `COMPOSE_PROFILES`
+> variable, running `docker compose up` directly will silently drop the three companion
+> services. Add `COMPOSE_PROFILES=companions` to your `.env` to restore the full set.
+> The setup script sets this default automatically.
+
+> **Docker Compose version required:** `>= 2.24.0` (for `--profile '*'` teardown and
+> `deploy.resources.limits` support). Check with `docker compose version`.
+
 ## Using DocCode
 
 ### Basic Diagram Creation

--- a/demoSite/js/main.js
+++ b/demoSite/js/main.js
@@ -35,7 +35,8 @@ import { processUrlParameters } from './modules/urlHandler.js';
 import {
     updateFormatDropdown,
     updateDiagram,
-    initializeDiagramTypeDropdown
+    initializeDiagramTypeDropdown,
+    applyDisabledDiagramTypes
 } from './modules/diagramOperations.js';
 
 // UI features
@@ -278,6 +279,9 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(config => {
             if (config.kroki && config.kroki.maxBodySize && window.configManager) {
                 window.configManager.set('editor.maxTextSize', config.kroki.maxBodySize);
+            }
+            if (config.kroki && Array.isArray(config.kroki.disabledDiagramTypes)) {
+                applyDisabledDiagramTypes(config.kroki.disabledDiagramTypes);
             }
             // Deliver server AI mode to the assistant so the UI reflects relay/byok/off
             if (config.ai && window.aiAssistant && typeof window.aiAssistant.applyServerMode === 'function') {

--- a/demoSite/js/modules/diagramOperations.js
+++ b/demoSite/js/modules/diagramOperations.js
@@ -179,6 +179,33 @@ export function updateImageLink() {
 }
 
 /**
+ * Remove server-disabled diagram types from the Type dropdown.
+ * Called once after /api/config resolves; idempotent.
+ *
+ * @param {string[]} disabledTypes - diagram type names to remove (case-insensitive)
+ * @param {HTMLSelectElement|null} [dropdownEl] - dropdown element; defaults to
+ *   document.getElementById('diagramType'). Pass explicitly for unit testing.
+ */
+export function applyDisabledDiagramTypes(disabledTypes, dropdownEl = null) {
+    if (!Array.isArray(disabledTypes) || disabledTypes.length === 0) return;
+    const dropdown = dropdownEl ?? (typeof document !== 'undefined' ? document.getElementById('diagramType') : null);
+    if (!dropdown) return;
+    const disabled = new Set(disabledTypes.map(t => String(t).toLowerCase()));
+    let selectionRemoved = false;
+    Array.from(dropdown.options).forEach(opt => {
+        if (disabled.has(opt.value.toLowerCase())) {
+            if (opt.value === dropdown.value) selectionRemoved = true;
+            opt.remove();
+        }
+    });
+    if (selectionRemoved) {
+        const plantumlOpt = dropdown.querySelector('option[value="plantuml"]');
+        dropdown.value = plantumlOpt ? 'plantuml' : (dropdown.options[0]?.value ?? '');
+        updateFormatDropdown();
+    }
+}
+
+/**
  * Initialize diagram type dropdown
  */
 export function initializeDiagramTypeDropdown() {

--- a/demoSite/js/modules/diagramRenderer.js
+++ b/demoSite/js/modules/diagramRenderer.js
@@ -120,9 +120,16 @@ export async function updateDiagram() {
         loadingMessage.style.display = 'none';
         loadingMessage.classList.remove('loading-pulse');
         const errorMessage = document.getElementById('errorMessage');
-        errorMessage.textContent = `Error: ${error.message}`;
+        // Rewrite raw 503 upstream text (e.g. "Connection refused: /127.0.0.1:800x")
+        // into a user-friendly message; keep the raw text in console for operators.
+        let displayMessage = error.message;
+        if (error.status === 503) {
+            console.warn('Render 503 raw:', error.message);
+            displayMessage = `The "${diagramType}" renderer is not available on this server (HTTP 503). It may be disabled in this deployment.`;
+        }
+        errorMessage.textContent = `Error: ${displayMessage}`;
         errorMessage.style.display = 'block';
-        dispatchRenderFailed(error.message);
+        dispatchRenderFailed(displayMessage);
     }
 }
 
@@ -169,16 +176,22 @@ async function renderImageDiagram(diagramImg, diagramViewport, zoomControls, url
         } else {
             const response = await fetch(url);
             if (!response.ok) {
-                let errorMessage = `HTTP ${response.status}`;
-                try {
-                    const errorText = await response.text();
-                    if (errorText && errorText.trim()) {
-                        errorMessage += `: ${errorText}`;
-                    } else {
+                let errorMessage;
+                if (response.status === 503) {
+                    try { console.warn('Render 503 raw:', await response.text()); } catch { /* ignore */ }
+                    errorMessage = `The "${diagramType}" renderer is not available on this server (HTTP 503). It may be disabled in this deployment.`;
+                } else {
+                    errorMessage = `HTTP ${response.status}`;
+                    try {
+                        const errorText = await response.text();
+                        if (errorText && errorText.trim()) {
+                            errorMessage += `: ${errorText}`;
+                        } else {
+                            errorMessage += `: ${response.statusText || 'Unknown error'}`;
+                        }
+                    } catch {
                         errorMessage += `: ${response.statusText || 'Unknown error'}`;
                     }
-                } catch {
-                    errorMessage += `: ${response.statusText || 'Unknown error'}`;
                 }
 
                 showBanner(errorMessage);

--- a/demoSite/server.py
+++ b/demoSite/server.py
@@ -77,6 +77,14 @@ AI_TIMEOUT_MAX = int(os.environ.get('AI_TIMEOUT_MAX', 300))  # Hard ceiling for 
 AI_MAX_TOKENS = 16000  # Token limit for AI responses
 MAX_REQUEST_SIZE = 1024 * 1024  # 1MB limit for AI requests
 KROKI_MAX_BODY_SIZE = int(os.environ.get('KROKI_MAX_BODY_SIZE', 1048576))  # Kroki backend body limit
+# Comma-separated diagram types disabled on this deployment (e.g. "bpmn,excalidraw,diagramsnet").
+# Delivered to this container via the existing env_file: .env on demosite (docker-compose.yml);
+# no compose change needed, but a container recreate (script restart) is required after editing.
+DISABLED_DIAGRAM_TYPES = [
+    t.strip().lower()
+    for t in os.environ.get('DISABLED_DIAGRAM_TYPES', '').split(',')
+    if t.strip()
+]
 
 # Enforced by Werkzeug even when the client omits Content-Length
 app.config['MAX_CONTENT_LENGTH'] = MAX_REQUEST_SIZE
@@ -807,7 +815,8 @@ def get_config():
             'server_url': os.environ.get('DRAWIO_SERVER_URL', 'https://embed.diagrams.net/')
         },
         'kroki': {
-            'maxBodySize': KROKI_MAX_BODY_SIZE
+            'maxBodySize': KROKI_MAX_BODY_SIZE,
+            'disabledDiagramTypes': DISABLED_DIAGRAM_TYPES
         }
     }
     return jsonify(config)

--- a/demoSite/tests/conftest.py
+++ b/demoSite/tests/conftest.py
@@ -22,6 +22,7 @@ os.environ.pop('AI_ACCESS_TOKEN', None)
 os.environ.pop('AI_MODEL_ALLOWLIST', None)
 os.environ.pop('AI_MODEL_FALLBACKS', None)
 os.environ.pop('AI_DAILY_LIMIT_PER_IP', None)
+os.environ.pop('DISABLED_DIAGRAM_TYPES', None)
 
 import pytest
 

--- a/demoSite/tests/disabledDiagramTypes.test.js
+++ b/demoSite/tests/disabledDiagramTypes.test.js
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for applyDisabledDiagramTypes (pure-logic, no real DOM needed).
+ *
+ * applyDisabledDiagramTypes accepts an optional dropdownEl parameter so it can
+ * be tested without a browser. We build a minimal fake <select> that mirrors the
+ * HTMLSelectElement API used by the function.
+ *
+ * diagramOperations.js imports 'pako' (a CDN dep unavailable to bun test).
+ * We mock it via Bun's module mock registry before any import of the module.
+ */
+
+import { test, mock } from 'bun:test';
+import { strictEqual, deepEqual, ok, doesNotThrow } from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Mock pako before diagramOperations.js is imported
+// ---------------------------------------------------------------------------
+mock.module('pako', () => ({
+    deflate: () => new Uint8Array(),
+    inflate: () => new Uint8Array(),
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal browser-global stubs required before importing diagramOperations.js
+// ---------------------------------------------------------------------------
+globalThis.window = globalThis;
+
+// Minimal DOM stub: getElementById returns a minimal element so that
+// updateFormatDropdown() (called when the selected item is removed) doesn't
+// throw. The stub element has value/innerHTML/options/appendChild/style.
+function makeStubElement() {
+    return {
+        value: 'plantuml',
+        innerHTML: '',
+        options: [],
+        style: {},
+        appendChild: () => {},
+        querySelector: () => null,
+    };
+}
+globalThis.document = {
+    getElementById: () => makeStubElement(),
+    createElement: (tag) => {
+        if (tag === 'option') return { value: '', textContent: '' };
+        return makeStubElement();
+    },
+};
+globalThis.navigator = {};
+
+// ---------------------------------------------------------------------------
+// Import the function under test
+// ---------------------------------------------------------------------------
+
+const { applyDisabledDiagramTypes } = await import('../js/modules/diagramOperations.js');
+
+// ---------------------------------------------------------------------------
+// Fake HTMLSelectElement factory
+// ---------------------------------------------------------------------------
+
+function makeSelect(optionValues, selectedValue = null) {
+    const options = optionValues.map(v => ({ value: v }));
+    let currentValue = selectedValue ?? (options[0]?.value ?? '');
+
+    const select = {
+        get options() { return options; },
+        get value() { return currentValue; },
+        set value(v) { currentValue = v; },
+        querySelector(sel) {
+            // Only handles 'option[value="plantuml"]' pattern used in the function
+            const m = sel.match(/option\[value="([^"]+)"\]/);
+            if (!m) return null;
+            return options.find(o => o.value === m[1]) ?? null;
+        },
+        remove() { /* unused at select level */ },
+    };
+
+    // Give each option a remove() that splices itself out
+    options.forEach((opt, i) => {
+        opt.remove = () => { options.splice(options.indexOf(opt), 1); };
+    });
+
+    return select;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('applyDisabledDiagramTypes: no-op on empty disabled list', () => {
+    const sel = makeSelect(['plantuml', 'bpmn', 'mermaid'], 'plantuml');
+    applyDisabledDiagramTypes([], sel);
+    strictEqual(sel.options.length, 3, 'no options removed');
+    strictEqual(sel.value, 'plantuml', 'selection unchanged');
+});
+
+test('applyDisabledDiagramTypes: no-op on non-array input', () => {
+    const sel = makeSelect(['plantuml', 'bpmn'], 'plantuml');
+    applyDisabledDiagramTypes(null, sel);
+    strictEqual(sel.options.length, 2);
+});
+
+test('applyDisabledDiagramTypes: removes named types (case-insensitive)', () => {
+    const sel = makeSelect(['plantuml', 'bpmn', 'excalidraw', 'diagramsnet'], 'plantuml');
+    applyDisabledDiagramTypes(['BPMN', 'Excalidraw', 'diagramsnet'], sel);
+    const remaining = sel.options.map(o => o.value);
+    deepEqual(remaining, ['plantuml'], 'only plantuml remains');
+    strictEqual(sel.value, 'plantuml', 'selection unchanged (plantuml was not disabled)');
+});
+
+test('applyDisabledDiagramTypes: falls back to plantuml when selected type is removed', () => {
+    const sel = makeSelect(['plantuml', 'bpmn', 'mermaid'], 'bpmn');
+    applyDisabledDiagramTypes(['bpmn'], sel);
+    ok(!sel.options.find(o => o.value === 'bpmn'), 'bpmn removed');
+    strictEqual(sel.value, 'plantuml', 'selection falls back to plantuml');
+});
+
+test('applyDisabledDiagramTypes: falls back to first option when plantuml also disabled', () => {
+    const sel = makeSelect(['graphviz', 'plantuml', 'mermaid'], 'plantuml');
+    applyDisabledDiagramTypes(['plantuml'], sel);
+    ok(!sel.options.find(o => o.value === 'plantuml'), 'plantuml removed');
+    // No plantuml left → falls back to options[0]
+    strictEqual(sel.value, 'graphviz', 'falls back to first remaining option');
+});
+
+test('applyDisabledDiagramTypes: no-op when dropdown element is null', () => {
+    // Should not throw when passed null explicitly
+    doesNotThrow(() => applyDisabledDiagramTypes(['bpmn'], null));
+});
+
+test('applyDisabledDiagramTypes: whitespace/mixed-case in disabled list', () => {
+    const sel = makeSelect(['plantuml', 'bpmn', 'excalidraw'], 'plantuml');
+    // The caller (main.js) passes the server-returned list which is already
+    // normalised by server.py; but the function itself lowercases for safety.
+    applyDisabledDiagramTypes(['  BPMN  '.trim(), 'Excalidraw'], sel);
+    const remaining = sel.options.map(o => o.value);
+    deepEqual(remaining, ['plantuml']);
+});

--- a/demoSite/tests/test_server.py
+++ b/demoSite/tests/test_server.py
@@ -424,3 +424,51 @@ def test_server_does_not_log_canary_key(client, server, upstream, monkeypatch, c
         post_ai(client, body=body)
     for record in caplog.records:
         assert 'sk-CANARY' not in record.getMessage()
+
+
+# --- DISABLED_DIAGRAM_TYPES / /api/config ----------------------------------------
+
+
+def test_config_disabled_diagram_types_empty_by_default(client, server, monkeypatch):
+    """/api/config returns an empty disabledDiagramTypes list when unset."""
+    monkeypatch.setattr(server, 'DISABLED_DIAGRAM_TYPES', [])
+    resp = client.get('/api/config')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['kroki']['disabledDiagramTypes'] == []
+
+
+def test_config_disabled_diagram_types_parsed(client, server, monkeypatch):
+    """DISABLED_DIAGRAM_TYPES is normalised (stripped, lowercased) and exposed."""
+    monkeypatch.setattr(
+        server,
+        'DISABLED_DIAGRAM_TYPES',
+        ['bpmn', 'excalidraw', 'diagramsnet'],
+    )
+    resp = client.get('/api/config')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['kroki']['disabledDiagramTypes'] == ['bpmn', 'excalidraw', 'diagramsnet']
+
+
+def test_disabled_diagram_types_normalisation():
+    """The module-level parsing strips whitespace, lowercases, and drops empties."""
+    import importlib
+    import os
+    import sys
+    # Reload server with the env var set to a dirty string.
+    os.environ['DISABLED_DIAGRAM_TYPES'] = 'bpmn, Excalidraw,,diagramsnet '
+    # Remove cached module so it re-parses env at import time.
+    for key in list(sys.modules.keys()):
+        if key == 'server':
+            del sys.modules[key]
+    try:
+        import server as fresh_server
+        assert fresh_server.DISABLED_DIAGRAM_TYPES == ['bpmn', 'excalidraw', 'diagramsnet']
+    finally:
+        os.environ.pop('DISABLED_DIAGRAM_TYPES', None)
+        # Restore original module reference so other tests keep working.
+        for key in list(sys.modules.keys()):
+            if key == 'server':
+                del sys.modules[key]
+        import server  # noqa: F401 — re-import canonical module

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
       - "8000"
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${CORE_CPU_LIMIT:-0}"
+          memory: "${CORE_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   mermaid:
     restart: unless-stopped
@@ -27,30 +37,73 @@ services:
       - "8002"
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${MERMAID_CPU_LIMIT:-0}"
+          memory: "${MERMAID_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   bpmn:
     restart: unless-stopped
     image: yuzutech/kroki-bpmn:0.30.1
+    profiles: ["companions", "bpmn"]
     expose:
       - "8003"
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${BPMN_CPU_LIMIT:-0}"
+          memory: "${BPMN_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   excalidraw:
     restart: unless-stopped
     image: yuzutech/kroki-excalidraw:0.30.1
+    profiles: ["companions", "excalidraw"]
     expose:
       - "8004"
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${EXCALIDRAW_CPU_LIMIT:-0}"
+          memory: "${EXCALIDRAW_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   diagramsnet:
     restart: unless-stopped
     image: yuzutech/kroki-diagramsnet:0.30.1
+    profiles: ["companions", "diagramsnet"]
     expose:
       - "8005"
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${DIAGRAMSNET_CPU_LIMIT:-0}"
+          memory: "${DIAGRAMSNET_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   demosite:
     restart: unless-stopped
@@ -64,6 +117,16 @@ services:
       - .env
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${DEMOSITE_CPU_LIMIT:-0}"
+          memory: "${DEMOSITE_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   nginx:
     restart: unless-stopped
@@ -78,6 +141,16 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     networks:
       - kroki_network
+    deploy:
+      resources:
+        limits:
+          cpus: "${NGINX_CPU_LIMIT:-0}"
+          memory: "${NGINX_MEM_LIMIT:-0}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   kroki_network:


### PR DESCRIPTION
## Summary

PR-5 of the [public-hosting plan](docs/public-hosting-plan-2026-06-12.md) (§4): the footprint controls that let a public demo run trimmed on a 4 GB box.

- **Compose profiles**: bpmn/excalidraw/diagramsnet carry `profiles: ["companions", "<name>"]`; core/mermaid/demosite/nginx stay profile-less (deliberately — a profile on default services would drop the whole stack for preserved-`.env` upgraders). `COMPOSE_PROFILES=companions` is the script default (PR-1), so existing deployments keep the full set; the public box sets it empty for core+mermaid only (~4.7 GB fewer images, ~0.5-1 GB less idle RAM).
- **Resource limits**: `deploy.resources.limits` on all 7 services with `${VAR:-0}` defaults — verified inert when unset (`Memory=0/NanoCpus=0` = unlimited) and active when set. Commented 4 GB-box values ship in `.env.example`.
- **Log rotation**: `json-file` capped at 10m×3 on every service — bounds disk growth on a 40 GB box (gunicorn now logs every request; nothing bounded the default driver).
- **Graceful disabled-renderer UX**: `DISABLED_DIAGRAM_TYPES` env → `/api/config` `kroki.disabledDiagramTypes` → the diagram-type dropdown prunes those entries at startup (with a selection fallback to plantuml), and render 503s for absent companions show "The <type> renderer is not available on this server" in **both** the GET and POST render paths (raw upstream text goes to the console for operators) instead of leaking `Connection refused: /127.0.0.1:8003`.

## Verification

- `COMPOSE_PROFILES= docker compose config --services` → exactly core/demosite/mermaid/nginx; `companions` → all 7; granular `bpmn` works.
- Limits inert/active behavior verified via rendered config; logging options present on all 7 services.
- 47/47 pytest + 54/54 bun (incl. new disabledDiagramTypes tests); `genconfig` output unchanged vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)