### PR TITLE
feat(render): nginx render cache, KROKI_SAFE_MODE pin, profile-driven abuse limits (PR-6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,3 +113,39 @@ COMPOSE_PROFILES=companions
 # the trimmed set: DISABLED_DIAGRAM_TYPES=bpmn,excalidraw,diagramsnet
 # Requires a container recreate (./setup-kroki-server.sh restart) to take effect.
 #DISABLED_DIAGRAM_TYPES=
+
+# --- Render-plane hardening (nginx render routes + Kroki core) ---------------
+# DEPLOY_PROFILE: private (default) keeps closed-network behavior — rate zones
+#   are defined but NO per-location limit_req/limit_conn directives, so batch
+#   pipelines and CI runners are never 429'd; body 10m, timeouts 300s.
+#   public applies strict limits for internet-facing instances: 10r/s burst 30,
+#   conn 20, body 1m, timeouts 30s. Override individual knobs below.
+#DEPLOY_PROFILE=private
+
+# KROKI_SAFE_MODE: secure (default) strips PlantUML !include/!includeurl of
+#   local files and remote URLs (SSRF/LFI guard). Standard library includes
+#   (<C4/C4_Context>, <aws/...>, etc.) still work. Set to safe +
+#   KROKI_PLANTUML_INCLUDE_WHITELIST only if you need local includes on a
+#   trusted network. Never use unsafe on a public instance.
+#KROKI_SAFE_MODE=secure
+
+# Kroki core request body cap in bytes (defense-in-depth behind nginx limit).
+#KROKI_BODY_LIMIT=10485760
+
+# nginx render cache — GET /<type>/<format>/<encoded> only.
+# POST and /api/ routes are NEVER cached.
+# After a core image upgrade, cached renders serve old-renderer output for up
+# to RENDER_CACHE_TTL. Flush: docker compose down && docker volume rm <proj>_nginx_cache
+#RENDER_CACHE_ENABLED=true
+#RENDER_CACHE_MAX_SIZE=500m
+#RENDER_CACHE_TTL=24h
+#RENDER_CACHE_INACTIVE=7d
+
+# Per-IP render limits. Defaults come from DEPLOY_PROFILE; override individually.
+# NOTE: the values shown below are the PUBLIC profile values. With the default
+# private profile these are NOT in effect — uncomment only to override.
+#RENDER_RATE=10r/s
+#RENDER_BURST=30
+#RENDER_CONN_LIMIT=20
+#RENDER_BODY_LIMIT=1m
+#RENDER_TIMEOUT=30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     image: ${KROKI_CORE_IMAGE:-ghcr.io/vppillai/kroki-core:goat}
     environment:
       - KROKI_MAX_URI_LENGTH=8192
+      - KROKI_SAFE_MODE=${KROKI_SAFE_MODE:-secure}
+      - KROKI_BODY_LIMIT=${KROKI_BODY_LIMIT:-10485760}
       - KROKI_MERMAID_HOST=mermaid
       - KROKI_BPMN_HOST=bpmn
       - KROKI_EXCALIDRAW_HOST=excalidraw
@@ -139,6 +141,7 @@ services:
     volumes:
       - ./nginx-certs:/etc/nginx/certs:ro
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - nginx_cache:/var/cache/nginx/kroki
     networks:
       - kroki_network
     deploy:
@@ -151,6 +154,9 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+volumes:
+  nginx_cache:
 
 networks:
   kroki_network:

--- a/setup-kroki-server.sh
+++ b/setup-kroki-server.sh
@@ -81,6 +81,70 @@ NGINX_SECURITY_HEADERS="    add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options SAMEORIGIN;
     add_header Content-Security-Policy \"default-src 'self'; script-src 'self' '${IMPORTMAP_SHA256}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https:; frame-src 'self' ${DRAWIO_ORIGIN}; object-src 'none'; base-uri 'self'; frame-ancestors 'self'\" always;"
 
+# --- Render-plane profile: cache + abuse limits (PR-6) ----------------------
+# DEPLOY_PROFILE=private (default): behavior-preserving for closed networks —
+#   zones are always emitted but NO per-location limit_req/limit_conn directives,
+#   so batch pipelines and CI runners are never 429'd. Body 10m, timeouts 300s.
+# DEPLOY_PROFILE=public: strict limits for an internet-facing instance.
+#   10r/s burst 30, conn 20, body 1m, timeouts 30s.
+# Every value is individually overridable via env (RENDER_RATE, RENDER_BURST, …).
+if [ "$DEPLOY_PROFILE" = "public" ]; then
+    RENDER_RATE="${RENDER_RATE:-10r/s}"
+    RENDER_BURST="${RENDER_BURST:-30}"
+    RENDER_CONN_LIMIT="${RENDER_CONN_LIMIT:-20}"
+    RENDER_BODY_LIMIT="${RENDER_BODY_LIMIT:-1m}"
+    RENDER_TIMEOUT="${RENDER_TIMEOUT:-30}"
+    RENDER_CONNECT_TIMEOUT="${RENDER_CONNECT_TIMEOUT:-10}"
+    # Under public profile, emit per-location limit directives.
+    NGINX_RENDER_LIMITS="            limit_req zone=render_req burst=${RENDER_BURST} nodelay;
+            limit_conn render_conn ${RENDER_CONN_LIMIT};"
+else
+    RENDER_RATE="${RENDER_RATE:-100r/s}"
+    RENDER_BURST="${RENDER_BURST:-200}"
+    RENDER_CONN_LIMIT="${RENDER_CONN_LIMIT:-100}"
+    RENDER_BODY_LIMIT="${RENDER_BODY_LIMIT:-10m}"
+    RENDER_TIMEOUT="${RENDER_TIMEOUT:-300}"
+    RENDER_CONNECT_TIMEOUT="${RENDER_CONNECT_TIMEOUT:-300}"
+    # Under private profile, zones exist but directives are omitted — no behavior change.
+    NGINX_RENDER_LIMITS=""
+fi
+
+RENDER_CACHE_ENABLED="${RENDER_CACHE_ENABLED:-true}"
+RENDER_CACHE_MAX_SIZE="${RENDER_CACHE_MAX_SIZE:-500m}"
+RENDER_CACHE_TTL="${RENDER_CACHE_TTL:-24h}"
+RENDER_CACHE_INACTIVE="${RENDER_CACHE_INACTIVE:-7d}"
+
+if [ "$RENDER_CACHE_ENABLED" = "true" ]; then
+    NGINX_CACHE_PATH_BLOCK="
+    # Render cache: GET /<type>/<format>/<encoded> is a pure function of the URL.
+    # Worst case after a core image upgrade: RENDER_CACHE_TTL (${RENDER_CACHE_TTL}) of
+    # old-renderer output. Flush with: docker compose down && docker volume rm <proj>_nginx_cache
+    proxy_cache_path /var/cache/nginx/kroki levels=1:2 keys_zone=kroki_render:10m
+                     max_size=${RENDER_CACHE_MAX_SIZE} inactive=${RENDER_CACHE_INACTIVE} use_temp_path=off;"
+    # add_header in a location cancels http-level add_header inheritance (nginx
+    # documented behaviour). The security headers MUST be restated here alongside
+    # X-Cache-Status — never add a lone add_header without the full set.
+    # Use a heredoc to avoid quote-collision with NGINX_SECURITY_HEADERS content.
+    NGINX_CACHE_LOCATION_BLOCK=$(cat <<CACHE_BLOCK
+
+            proxy_cache kroki_render;
+            # \$request_method in the key guards against future proxy_cache_convert_head off
+            # configs where a HEAD could land as a separate cache entry.
+            proxy_cache_key "\$request_method\$request_uri";
+            proxy_ignore_headers Cache-Control Expires;
+            proxy_cache_valid 200 ${RENDER_CACHE_TTL};
+            proxy_cache_valid 400 404 1m;
+            proxy_cache_lock on;
+            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            # Restate security headers: add_header in this location cancels http-level inheritance.
+${NGINX_SECURITY_HEADERS}
+            add_header X-Cache-Status \$upstream_cache_status always;
+CACHE_BLOCK
+)
+else
+    NGINX_CACHE_PATH_BLOCK=""
+    NGINX_CACHE_LOCATION_BLOCK=""
+fi
 # ---------------------------------------------------------------------------
 
 # Check if docker is installed
@@ -236,6 +300,15 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     client_max_body_size 10M;  # Allow larger diagram requests
+${NGINX_CACHE_PATH_BLOCK}
+    # Per-IP abuse limits on render routes; values chosen by DEPLOY_PROFILE.
+    # Zones always emitted (both profiles); per-location directives only under public.
+    # 10m zone ≈ tens of thousands of tracked client IPs.
+    limit_req_zone \$binary_remote_addr zone=render_req:10m rate=${RENDER_RATE};
+    limit_conn_zone \$binary_remote_addr zone=render_conn:10m;
+    limit_req_status 429;
+    limit_conn_status 429;
+    limit_req_log_level warn;
 
     # Security headers
 ${NGINX_SECURITY_HEADERS}
@@ -313,30 +386,38 @@ ${NGINX_SECURITY_HEADERS}
         }
 
         # Kroki API POST requests (diagram-type/format) - exclude /api/ paths
+        # POST render path: limits/timeouts only; NEVER proxy_cache (POST not idempotent).
         location ~* ^/(?!api/)([^/]+)/([^/]+)$ {
             limit_except GET POST {
                 deny all;
             }
+${NGINX_RENDER_LIMITS}
+            client_max_body_size ${RENDER_BODY_LIMIT};
             proxy_pass http://core:${DEFAULT_HTTP_PORT};
             proxy_set_header Host \$host;
             proxy_set_header X-Real-IP \$remote_addr;
             proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
-            proxy_connect_timeout 300;
-            proxy_send_timeout 300;
-            proxy_read_timeout 300;
+            proxy_connect_timeout ${RENDER_CONNECT_TIMEOUT};
+            proxy_send_timeout ${RENDER_TIMEOUT};
+            proxy_read_timeout ${RENDER_TIMEOUT};
         }
 
         # Match Kroki API pattern (diagram-type/format/encoded-diagram) - exclude /api/ paths
+        # GET render path: cached (when RENDER_CACHE_ENABLED=true). limit_req runs in
+        # the preaccess phase, so cache HITs also count against the per-IP rate (desired).
         location ~* ^/(?!api/)[^/]+/[^/]+/[^/]+$ {
+${NGINX_RENDER_LIMITS}
+            client_max_body_size ${RENDER_BODY_LIMIT};
             proxy_pass http://core:${DEFAULT_HTTP_PORT};
             proxy_set_header Host \$host;
             proxy_set_header X-Real-IP \$remote_addr;
             proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
-            proxy_connect_timeout 300;
-            proxy_send_timeout 300;
-            proxy_read_timeout 300;
+            proxy_connect_timeout ${RENDER_CONNECT_TIMEOUT};
+            proxy_send_timeout ${RENDER_TIMEOUT};
+            proxy_read_timeout ${RENDER_TIMEOUT};
+${NGINX_CACHE_LOCATION_BLOCK}
         }
 
         # Fallback for any other paths
@@ -502,9 +583,14 @@ show_help() {
     echo "              prints resolved TLS_MODE, DEPLOY_PROFILE, COMPOSE_PROFILES"
     echo ""
     echo "Deployment parameters (set via .env or environment):"
-    echo "  TLS_MODE          selfsigned (default) | acme"
-    echo "  DEPLOY_PROFILE    private (default) | public"
-    echo "  COMPOSE_PROFILES  companions (default) | empty for core-only"
+    echo "  TLS_MODE             selfsigned (default) | acme"
+    echo "  DEPLOY_PROFILE       private (default) | public"
+    echo "  COMPOSE_PROFILES     companions (default) | empty for core-only"
+    echo "  RENDER_CACHE_ENABLED true (default) | false"
+    echo "  RENDER_CACHE_MAX_SIZE 500m (default)"
+    echo "  RENDER_CACHE_TTL     24h (default)"
+    echo "  RENDER_CACHE_INACTIVE 7d (default)"
+    echo "  RENDER_RATE/BURST/CONN_LIMIT/BODY_LIMIT/TIMEOUT — per-profile render limits"
     echo ""
 }
 


### PR DESCRIPTION
## Summary

PR-6 of the [public-hosting plan](docs/public-hosting-plan-2026-06-12.md) (§4): the render plane becomes cheap and abuse-resistant.

- **Render cache** (`RENDER_CACHE_ENABLED=true` default): GET renders are pure functions of the URL, so a 500 MB nginx disk cache (`nginx_cache` named volume) turns repeat renders into ~free 200s — `proxy_cache_valid 200 24h`, 1m TTL on 400/404 to absorb bad-input hammering, `proxy_cache_lock` + `use_stale` for thundering herds and upstream blips, `X-Cache-Status` for observability. POST renders are never cached. Empirically verified MISS→HIT against the generated config, **with all security headers including CSP present on cached responses** — the header-restatement rule from the shared fragment doing its job (nginx cancels http-level `add_header` inheritance in any location that declares its own).
- **`KROKI_SAFE_MODE=secure` pin** on core: a verified no-op confirmation (the pinned image already defaults secure — source + empirical SSRF probes at the digest, see the planning record); the explicit pin guards future rebuilds. Plus `KROKI_BODY_LIMIT` (core previously had no body limit at all — Vert.x default is unlimited).
- **Profile-driven abuse limits**: `DEPLOY_PROFILE=public` puts `limit_req 10r/s burst=30` + `limit_conn 20` + 1m body + 30s timeouts on the render routes (verified: 60-request concurrent burst → 28×200/32×429). **`private` (default) is behavior-preserving**: zones are emitted but no per-location limit directives, timeouts stay 300s, body stays 10m — existing closed-network deployments see only the cache as a delta on next restart.

## Verification

- `genconfig` matrix: private (no limit directives, 300s kept, CSP inside the cached location), public (limits present), cache-disabled (no `proxy_cache_path`) — all pass `nginx -t` in `nginx:1.28-alpine`.
- Live behavior against a fake upstream: MISS→HIT, headers-on-cached, burst mix, no `X-Cache-Status` on POST.
- `docker compose config`: `KROKI_SAFE_MODE=secure` on core, `nginx_cache` volume wired; suites untouched (47 pytest / 58 bun).
- Cache flush procedure documented in the generated config comment; `clean` removes the volume via PR-1's `down -v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)