### PR TITLE
feat(tls): TLS_MODE=acme — Let's Encrypt issuance, renewal sidecar, HSTS (PR-7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,44 @@ HTTPS_PORT=8443
 DEMOSITE_CONTAINER_PORT=8006
 
 # Hostname (single value only)
+# In TLS_MODE=acme this must be your public DNS name (e.g. demo.example.com).
+# Note: HTTP_PORT below is the Kroki core CONTAINER port used in nginx proxy_pass
+# directives — it is never published to the host. The only host-published ports
+# are HTTPS_PORT (always) and ACME_HTTP_PORT (acme mode only).
 HOSTNAME=localhost
+
+# TLS configuration
+# TLS_MODE=selfsigned (default): self-signed ECDSA cert in ./nginx-certs, for
+#   closed networks. No new requirements — works exactly as before.
+# TLS_MODE=acme: real Let's Encrypt certificate via certbot. Requires:
+#   - HOSTNAME set to your public DNS name (not localhost, not dotless)
+#   - HTTPS_PORT=443  (browser Origin 'https://domain' matches — no app changes needed)
+#   - Host ports 80 and 443 reachable from the internet (check cloud firewall)
+#   - ACME_EMAIL set below
+#   First run: certbot issues the cert standalone (nginx stopped briefly).
+#   Renewals: the certbot sidecar (docker-compose.acme.yml) runs every 12h;
+#   nginx reloads the new cert every 6h. Also install the daily cron backstop:
+#     sudo crontab -e  →  0 9 * * * /opt/kroki-server/scripts/check-cert-expiry.sh
+TLS_MODE=selfsigned
+
+# Contact email for Let's Encrypt expiry notices (required when TLS_MODE=acme).
+#ACME_EMAIL=""
+
+# Set ACME_STAGING=1 while testing ACME: uses the Let's Encrypt STAGING CA
+# (untrusted certs, but no rate limits). Procedure:
+#   1. Set ACME_STAGING=1 → ./setup-kroki-server.sh start
+#   2. Verify the cert issuer contains "STAGING" (curl -vk https://<domain>/)
+#   3. rm -rf ./letsencrypt → unset ACME_STAGING → ./setup-kroki-server.sh restart
+#ACME_STAGING=""
+
+# Host port for the ACME HTTP-01 challenge listener and HTTP→HTTPS redirect.
+# Must be reachable from Let's Encrypt servers (i.e. externally accessible port 80).
+# Default: 80 (standard). Override only if your firewall maps a different port.
+#ACME_HTTP_PORT=80
+
+# Optional webhook URL for scripts/check-cert-expiry.sh alerts (ntfy-compatible:
+# plain-text POST body, Title header). Example: https://ntfy.sh/your-topic
+#CERT_ALERT_WEBHOOK=""
 
 # AI Configuration (Always uses proxy for maximum flexibility)
 # Proxy supports: LiteLLM, OpenRouter, or any OpenAI-compatible API

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ __pycache__/
 # Local environment (may contain secrets) — do not commit
 .env
 !.env.example
+
+# Let's Encrypt state (TLS_MODE=acme) — preserved across deploys, never commit.
+# WARNING: never run 'git clean -xdf' in the production checkout — it would
+# delete ./letsencrypt alongside other untracked files, burning Let's Encrypt
+# duplicate-certificate quota (5 identical-name-set certs/week).
+letsencrypt/
+certbot-webroot/

--- a/docker-compose.acme.yml
+++ b/docker-compose.acme.yml
@@ -1,0 +1,40 @@
+# ACME/Let's Encrypt overlay — applied automatically by setup-kroki-server.sh
+# when TLS_MODE=acme in .env. Never used in the default self-signed setup.
+#
+# Compose v2 merge semantics:
+#   - ports/volumes entries APPEND to the nginx service defined in docker-compose.yml
+#     (base already publishes ${HTTPS_PORT:-8443}:8443; this overlay adds 80:8080).
+#   - command REPLACES the base image default, bypassing docker-entrypoint.d scripts
+#     (acceptable: our nginx.conf is fully rendered by setup-kroki-server.sh and
+#     requires no envsubst/template processing from the image's entrypoint).
+#   - The certbot service joins kroki_network defined in docker-compose.yml.
+
+services:
+  nginx:
+    ports:
+      - "${ACME_HTTP_PORT:-80}:8080"
+    volumes:
+      - ./letsencrypt:/etc/letsencrypt:ro
+      - ./certbot-webroot:/var/www/certbot:ro
+    # Reload nginx every 6h so renewed certs are picked up without a full restart.
+    # Certbot renews ~30 days before expiry so a ≤6h pickup lag is irrelevant.
+    # Note: this command form skips the image's docker-entrypoint.d scripts —
+    # acceptable because our nginx.conf is fully rendered (no template/envsubst needed).
+    command: /bin/sh -c "(while :; do sleep 6h; nginx -s reload; done) & exec nginx -g 'daemon off;'"
+
+  certbot:
+    image: certbot/certbot:v4.0.0
+    restart: unless-stopped
+    volumes:
+      - ./letsencrypt:/etc/letsencrypt
+      - ./certbot-webroot:/var/www/certbot
+    # Twice-daily renewal check; webroot challenges are served by nginx's :8080 listener.
+    # $$ in YAML escapes to a single $ in the shell, so $$! becomes $! (the background PID).
+    entrypoint: /bin/sh -c "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot --quiet; sleep 12h & wait $$!; done"
+    networks:
+      - kroki_network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docs/acme-tls.md
+++ b/docs/acme-tls.md
@@ -1,0 +1,118 @@
+# Real TLS with Let's Encrypt (TLS_MODE=acme)
+
+Add four lines to your `.env` to switch from the self-signed default to a real
+Let's Encrypt certificate:
+
+```bash
+HOSTNAME=demo.example.com   # your public DNS name
+HTTPS_PORT=443
+TLS_MODE=acme
+ACME_EMAIL=ops@example.com  # Let's Encrypt expiry notices
+```
+
+## Prerequisites checklist
+
+Before running `./setup-kroki-server.sh start` in acme mode, verify:
+
+1. **DNS A record** — `dig +short A demo.example.com` returns your box's public
+   IPv4. If an AAAA record exists it **must** also point at this box (Let's
+   Encrypt prefers IPv6 and will use it if present).
+2. **Ports open** — host ports 80 and 443 are open in your cloud
+   firewall/security group and not held by another service:
+   `sudo ss -ltnp 'sport = :80 or sport = :443'` should show nothing (or only
+   Docker's proxy process after the stack starts).
+3. **No blocking CAA record** — `dig +short CAA example.com` is empty **or**
+   includes `0 issue "letsencrypt.org"`.
+4. **`.env` has a literal `HOSTNAME=` line** — acme mode reads HOSTNAME by
+   parsing `.env` directly (the bash shell builtin `HOSTNAME` is always set to
+   the machine hostname and is deliberately ignored).
+
+## Staging-first procedure (strongly recommended)
+
+Let's Encrypt staging has no rate limits; production has 5 duplicate-name certs
+per week. **Always test with staging before going to production.**
+
+```bash
+# 1. Add to .env:
+ACME_STAGING=1
+
+# 2. Issue the staging cert and start the stack:
+./setup-kroki-server.sh start
+
+# 3. Verify the cert is from the STAGING CA:
+curl -vk https://demo.example.com/ 2>&1 | grep -i "issuer"
+# Expect: "(STAGING)" in the issuer string
+
+# 4. Tear down staging cert and re-issue for production:
+rm -rf ./letsencrypt
+# Remove or comment out ACME_STAGING from .env
+./setup-kroki-server.sh restart
+```
+
+## Let's Encrypt rate limits
+
+| Limit | Value |
+|-------|-------|
+| Duplicate certs (same name set) | 5 per week |
+| Failed validation attempts | 5 per account+hostname per hour |
+| New orders per account | ~300 per 3 hours |
+
+`./setup-kroki-server.sh clean` **deliberately preserves `./letsencrypt`** to
+avoid burning the duplicate-cert quota on repeated clean+start cycles.
+
+**WARNING:** never run `git clean -xdf` in the production checkout — it deletes
+`./letsencrypt` (and `.env`) alongside other untracked files. Use
+`git clean -xdf --exclude=letsencrypt --exclude=.env` if you must clean.
+
+## Renewal mechanics
+
+Renewal is fully automatic via three overlapping mechanisms:
+
+1. **Certbot sidecar** (`docker-compose.acme.yml`): runs `certbot renew` every
+   12 hours. Certbot renews when the cert has <30 days remaining.
+2. **nginx graceful reload** (overlay `command`): runs `nginx -s reload` every
+   6 hours, picking up the renewed cert without any downtime.
+3. **Daily cron backstop** (`scripts/check-cert-expiry.sh`): alerts at <21 days
+   remaining, giving ~9 days to intervene if both of the above have been failing.
+
+Install the cron backstop as root (letsencrypt directories are 0700 root-only):
+
+```bash
+sudo crontab -e
+# Add:
+0 9 * * * /opt/kroki-server/scripts/check-cert-expiry.sh
+```
+
+Optional alert webhook (ntfy-compatible, e.g. `https://ntfy.sh/your-topic`):
+
+```bash
+CERT_ALERT_WEBHOOK=https://ntfy.sh/your-topic   # in .env
+```
+
+## Rollback: acme → selfsigned
+
+If you need to revert to self-signed:
+
+1. Change `TLS_MODE=acme` to `TLS_MODE=selfsigned` in `.env`
+2. `./setup-kroki-server.sh restart`
+
+**HSTS caveat:** acme mode emits `Strict-Transport-Security: max-age=86400`.
+Browsers that received this header will refuse HTTP connections to your hostname
+for up to 24 hours after rollback. The 86400 (1 day) initial value is deliberate
+rollback safety — raise it to `max-age=31536000` in the NGINX_SECURITY_HEADERS
+fragment a week after a successful public launch.
+
+## Switching TLS_MODE on a running stack
+
+Always stop the stack before switching `TLS_MODE` between `acme` and
+`selfsigned`:
+
+```bash
+./setup-kroki-server.sh stop
+# edit TLS_MODE in .env
+./setup-kroki-server.sh start
+```
+
+Switching while the stack is running leaves the certbot container as an orphan
+(compose only warns). The `--remove-orphans` flag in `restart` and `stop` cleans
+these up automatically.

--- a/scripts/check-cert-expiry.sh
+++ b/scripts/check-cert-expiry.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Daily cron backstop: alert when the Let's Encrypt certificate is <21 days from
+# expiry. Certbot renews at <30 days, so firing means renewal has been failing
+# for ~9 days — enough lead time to intervene before the cert expires.
+#
+# Install on the public box (must run as root — letsencrypt/live/ is 0700 root):
+#   sudo crontab -e
+#   0 9 * * * /opt/kroki-server/scripts/check-cert-expiry.sh
+#
+# Optional webhook (ntfy-compatible, plain-text POST with a Title header):
+#   Add CERT_ALERT_WEBHOOK=https://ntfy.sh/your-topic to /opt/kroki-server/.env
+#
+# Environment variables honoured (all optional except HOSTNAME in .env):
+#   CERT_ALERT_DAYS    Days threshold for the warning (default: 21)
+#   CERT_ALERT_WEBHOOK Webhook URL to POST alerts to (ntfy-compatible)
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Load .env — but do NOT rely on the bash builtin HOSTNAME (bash always sets
+# HOSTNAME to the machine hostname, which silently bypasses any .env value).
+# Unset the builtin before sourcing so the .env HOSTNAME= line takes effect.
+unset HOSTNAME
+# shellcheck source=/dev/null
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+    set -a
+    source "${SCRIPT_DIR}/.env"
+    set +a
+fi
+
+# Read HOSTNAME strictly from the .env file via grep (never from the environment)
+# so a missing .env HOSTNAME= line is a config error, not a silent machine-name lookup.
+if [ ! -f "${SCRIPT_DIR}/.env" ]; then
+    echo "ERROR: .env not found at ${SCRIPT_DIR}/.env" >&2
+    exit 1
+fi
+
+ENV_HOSTNAME="$(grep '^HOSTNAME=' "${SCRIPT_DIR}/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+if [ -z "${ENV_HOSTNAME}" ]; then
+    echo "ERROR: HOSTNAME is not set in ${SCRIPT_DIR}/.env — cannot locate certificate." >&2
+    exit 1
+fi
+
+DOMAIN="${ENV_HOSTNAME}"
+CERT="${SCRIPT_DIR}/letsencrypt/live/${DOMAIN}/fullchain.pem"
+THRESHOLD_DAYS="${CERT_ALERT_DAYS:-21}"
+
+fail() {
+    local msg="$1"
+    logger -t doccode-cert "ALERT: ${msg}"
+    if [ -n "${CERT_ALERT_WEBHOOK:-}" ]; then
+        curl -fsS -m 10 \
+            -H "Title: DocCode TLS Alert (${DOMAIN})" \
+            -d "DocCode TLS alert (${DOMAIN}): ${msg}" \
+            "${CERT_ALERT_WEBHOOK}" || true
+    fi
+    echo "ALERT: ${msg}" >&2
+    exit 1
+}
+
+if [ ! -f "${CERT}" ]; then
+    fail "certificate file missing: ${CERT}"
+fi
+
+if ! openssl x509 -checkend "$((THRESHOLD_DAYS * 86400))" -noout -in "${CERT}"; then
+    fail "certificate expires within ${THRESHOLD_DAYS} days — renewal is failing (check 'docker compose logs certbot' and that port 80 is reachable from the internet)"
+fi
+
+echo "OK: ${DOMAIN} cert valid for >${THRESHOLD_DAYS} days"

--- a/setup-kroki-server.sh
+++ b/setup-kroki-server.sh
@@ -51,8 +51,13 @@ fi
 # PR-4 (compose-footprint) enables the companions profile by default.
 export COMPOSE_PROFILES="${COMPOSE_PROFILES-companions}"
 
-# TLS mode: selfsigned (default, closed-network) or acme (PR-6).
+# TLS mode: selfsigned (default, closed-network) or acme (PR-7).
 TLS_MODE="${TLS_MODE:-selfsigned}"
+
+# ACME/Let's Encrypt paths and options (only used when TLS_MODE=acme).
+LETSENCRYPT_DIR="${SCRIPT_DIR}/letsencrypt"
+CERTBOT_WEBROOT_DIR="${SCRIPT_DIR}/certbot-webroot"
+ACME_HTTP_PORT="${ACME_HTTP_PORT:-80}"
 
 # Deployment profile: private (default, closed-network) or public (PR-5).
 DEPLOY_PROFILE="${DEPLOY_PROFILE:-private}"
@@ -80,6 +85,15 @@ NGINX_SECURITY_HEADERS="    add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection \"1; mode=block\";
     add_header X-Frame-Options SAMEORIGIN;
     add_header Content-Security-Policy \"default-src 'self'; script-src 'self' '${IMPORTMAP_SHA256}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https:; frame-src 'self' ${DRAWIO_ORIGIN}; object-src 'none'; base-uri 'self'; frame-ancestors 'self'\" always;"
+# ACME mode: append HSTS to the shared fragment so it is inherited everywhere
+# (http-level add_header is inherited only when a location/server defines none;
+# the shared fragment is restated inside every location that adds its own
+# add_header, so HSTS is covered everywhere in acme mode). Initial max-age=86400
+# (1 day) for rollback safety — raise to 31536000 a week after launch.
+if [ "$TLS_MODE" = "acme" ]; then
+    NGINX_SECURITY_HEADERS="${NGINX_SECURITY_HEADERS}
+    add_header Strict-Transport-Security \"max-age=86400\" always;"
+fi
 
 # --- Render-plane profile: cache + abuse limits (PR-6) ----------------------
 # DEPLOY_PROFILE=private (default): behavior-preserving for closed networks —
@@ -187,8 +201,10 @@ check_dependencies() {
 
     # DOCKER_COMPOSE always carries its -f file list so every subcommand
     # (start/stop/restart/clean/logs/status) sees the same file set.
-    # PR-6 (tls-acme) will append -f docker-compose.acme.yml here when TLS_MODE=acme.
     DOCKER_COMPOSE="$DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE"
+    if [ "$TLS_MODE" = "acme" ]; then
+        DOCKER_COMPOSE="$DOCKER_COMPOSE -f ${SCRIPT_DIR}/docker-compose.acme.yml"
+    fi
 }
 
 # Function to generate ECDSA self-signed SSL certs or use existing ones
@@ -233,6 +249,63 @@ generate_certs() {
     else
         echo "SSL certificate already exists."
     fi
+}
+
+# Validate ACME configuration: called from start/restart when TLS_MODE=acme.
+# Requirements: literal ^HOSTNAME= in .env (never trust bash builtin HOSTNAME —
+# bash sets it unconditionally to the machine hostname); HOSTNAME must be a
+# public FQDN (not localhost, not dotless); ACME_EMAIL must be set.
+validate_acme_config() {
+    # Require a literal HOSTNAME= line in .env — the bash builtin can shadow it
+    if [ ! -f "${SCRIPT_DIR}/.env" ] || ! grep -q '^HOSTNAME=' "${SCRIPT_DIR}/.env"; then
+        echo "Error: TLS_MODE=acme requires HOSTNAME to be set explicitly in .env (not just the shell environment)."
+        echo "  Add a line like: HOSTNAME=demo.example.com"
+        exit 1
+    fi
+    if [ "${DEFAULT_HOSTNAME}" = "localhost" ] || ! echo "${DEFAULT_HOSTNAME}" | grep -q '\.'; then
+        echo "Error: TLS_MODE=acme requires HOSTNAME to be a public DNS name (got '${DEFAULT_HOSTNAME}')."
+        echo "  HOSTNAME must contain at least one dot and must not be 'localhost'."
+        exit 1
+    fi
+    if [ -z "${ACME_EMAIL:-}" ]; then
+        echo "Error: TLS_MODE=acme requires ACME_EMAIL to be set in .env."
+        exit 1
+    fi
+    if [ "${DEFAULT_HTTPS_PORT}" != "443" ]; then
+        echo "Warning: TLS_MODE=acme expects HTTPS_PORT=443 for public ACME; the HTTP->HTTPS redirect assumes the standard port."
+        echo "  Current HTTPS_PORT=${DEFAULT_HTTPS_PORT}. Proceeding, but browsers may not hit the redirect correctly."
+    fi
+}
+
+# Issue a Let's Encrypt certificate via certbot standalone (first issuance only).
+# Skipped when the certificate already exists (avoid hitting LE duplicate-cert limits).
+# ECDSA key type is mandatory: the nginx cipher list is ECDSA-only (ECDHE-ECDSA-*);
+# an RSA cert would fail every TLS handshake.
+ensure_acme_cert() {
+    mkdir -p "$LETSENCRYPT_DIR" "$CERTBOT_WEBROOT_DIR"
+    if [ -f "${LETSENCRYPT_DIR}/live/${DEFAULT_HOSTNAME}/fullchain.pem" ]; then
+        echo "ACME certificate for ${DEFAULT_HOSTNAME} already present — skipping issuance."
+        return 0
+    fi
+    echo "Issuing Let's Encrypt certificate for ${DEFAULT_HOSTNAME} (standalone, host port ${ACME_HTTP_PORT})..."
+    echo "  Note: nginx cannot start until the cert exists; certbot binds port ${ACME_HTTP_PORT} directly."
+    # Stop our own nginx if it is already running so certbot can bind the port
+    $DOCKER_COMPOSE stop nginx >/dev/null 2>&1 || true
+    local staging_flag=""
+    if [ -n "${ACME_STAGING:-}" ] && [ "${ACME_STAGING}" != "0" ]; then
+        staging_flag="--staging"
+        echo "  ACME_STAGING=1 — using Let's Encrypt STAGING CA (untrusted cert, generous limits)."
+    fi
+    docker run --rm -p "${ACME_HTTP_PORT}:80" \
+        -v "${LETSENCRYPT_DIR}:/etc/letsencrypt" \
+        -v "${CERTBOT_WEBROOT_DIR}:/var/www/certbot" \
+        certbot/certbot:v4.0.0 certonly --standalone \
+        --key-type ecdsa --elliptic-curve secp256r1 \
+        -d "${DEFAULT_HOSTNAME}" \
+        --email "${ACME_EMAIL}" \
+        --agree-tos --no-eff-email --non-interactive \
+        ${staging_flag}
+    echo "Certificate issued successfully."
 }
 
 # Function to build demo site
@@ -284,6 +357,38 @@ ensure_kroki_core() {
 # Function to create Nginx config
 create_nginx_config() {
     echo "Creating Nginx configuration..."
+    # Compute TLS-mode-dependent locals BEFORE the heredoc.
+    # In acme mode: cert paths point into ./letsencrypt/live/<hostname>/;
+    # the ACME_HTTP_SERVER fragment adds the :8080 HTTP-01 challenge listener.
+    # In selfsigned mode: paths and fragment are identical to main's output
+    # (byte-for-byte regression guarantee).
+    local ssl_cert="/etc/nginx/certs/nginx.crt"
+    local ssl_key="/etc/nginx/certs/nginx.key"
+    local acme_http_server=""
+    if [ "$TLS_MODE" = "acme" ]; then
+        ssl_cert="/etc/letsencrypt/live/${DEFAULT_HOSTNAME}/fullchain.pem"
+        ssl_key="/etc/letsencrypt/live/${DEFAULT_HOSTNAME}/privkey.pem"
+        # Note: \$host and \$request_uri below are nginx runtime variables;
+        # they are escaped here so they pass through the heredoc unexpanded
+        # and reach nginx.conf as literal $host / $request_uri.
+        acme_http_server="
+    # ACME HTTP-01 challenge listener + HTTP->HTTPS redirect.
+    # Certbot renewal webroot requests are served from /var/www/certbot
+    # (mounted from ./certbot-webroot by docker-compose.acme.yml).
+    server {
+        listen 0.0.0.0:8080;
+        server_name ${DEFAULT_HOSTNAME};
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://\$host\$request_uri;
+        }
+    }
+"
+    fi
     cat > "$NGINX_CONF" <<EOF
 events {
     worker_connections 1024;
@@ -319,13 +424,21 @@ ${NGINX_SECURITY_HEADERS}
     ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384';
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
+EOF
+    # Conditionally inject the ACME HTTP-01 server block BEFORE the HTTPS server.
+    # In selfsigned mode acme_http_server is empty and nothing is appended here,
+    # preserving byte-identical output with the pre-acme baseline.
+    if [ -n "$acme_http_server" ]; then
+        printf '%s' "$acme_http_server" >> "$NGINX_CONF"
+    fi
+    cat >> "$NGINX_CONF" <<EOF
 
     server {
         listen 0.0.0.0:8443 ssl;
         server_name ${DEFAULT_HOSTNAME};
 
-        ssl_certificate /etc/nginx/certs/nginx.crt;
-        ssl_certificate_key /etc/nginx/certs/nginx.key;
+        ssl_certificate ${ssl_cert};
+        ssl_certificate_key ${ssl_key};
 
         # Root path (serves the demo site index)
         location = / {
@@ -450,6 +563,20 @@ check_services() {
         sleep $sleep_time
         attempt=$((attempt + 1))
     done
+
+    # Hairpin-NAT fallback for acme mode: some cloud providers do not loop the
+    # public IP back to the same host (no hairpin/NAT loopback). If the public
+    # hostname check failed, retry via 127.0.0.1 with --resolve so TLS SNI
+    # still matches the real hostname.
+    if [ "$TLS_MODE" = "acme" ]; then
+        echo "Public hostname check failed — trying hairpin-NAT fallback via 127.0.0.1..."
+        if curl -k -s -o /dev/null -w "%{http_code}" \
+            --resolve "${DEFAULT_HOSTNAME}:${DEFAULT_HTTPS_PORT}:127.0.0.1" \
+            "https://${DEFAULT_HOSTNAME}:${DEFAULT_HTTPS_PORT}" | grep -q "200"; then
+            echo "Services are up and running (reachable via 127.0.0.1 — hairpin-NAT not available on this host)!"
+            return 0
+        fi
+    fi
 
     echo "Error: Services did not start properly. Check logs with '$0 logs'"
     return 1
@@ -592,6 +719,12 @@ show_help() {
     echo "  RENDER_CACHE_INACTIVE 7d (default)"
     echo "  RENDER_RATE/BURST/CONN_LIMIT/BODY_LIMIT/TIMEOUT — per-profile render limits"
     echo ""
+    echo "ACME/Let's Encrypt parameters (TLS_MODE=acme only):"
+    echo "  ACME_EMAIL           Contact email for Let's Encrypt (required)"
+    echo "  ACME_STAGING         Set to 1 to use the LE staging CA (test first!)"
+    echo "  ACME_HTTP_PORT       Host port for HTTP-01 challenge/redirect (default: 80)"
+    echo "  CERT_ALERT_WEBHOOK   Optional webhook URL for scripts/check-cert-expiry.sh"
+    echo ""
 }
 
 # Main logic
@@ -607,7 +740,12 @@ fi
 
 case "$COMMAND" in
     start)
-        generate_certs
+        if [ "$TLS_MODE" = "acme" ]; then
+            validate_acme_config
+            ensure_acme_cert
+        else
+            generate_certs
+        fi
         create_nginx_config
         build_demo_site
         ensure_kroki_core
@@ -643,13 +781,30 @@ case "$COMMAND" in
         echo "Removing generated files..."
         rm -rf "$CERTS_DIR"
         rm -f "$NGINX_CONF"
+        # ./letsencrypt is intentionally NOT removed: Let's Encrypt enforces a
+        # duplicate-certificate limit of 5 certs/week for the same name set.
+        # Re-issuing after every clean would exhaust this quota quickly.
+        # Delete ./letsencrypt manually only when you genuinely need a fresh cert.
+        # WARNING: never run 'git clean -xdf' in a production checkout — it would
+        # delete ./letsencrypt alongside other untracked files.
+        if [ -d "${LETSENCRYPT_DIR}" ]; then
+            echo "Preserving ./letsencrypt (Let's Encrypt rate limits) — delete manually if you really mean it."
+        fi
+        if [ -d "${CERTBOT_WEBROOT_DIR}" ]; then
+            echo "Preserving ./certbot-webroot — delete manually if needed."
+        fi
         echo "Cleaned up Docker containers, images, and generated files."
         ;;
     restart)
         echo "Restarting services with Docker Compose..."
         $DOCKER_COMPOSE --profile '*' down --remove-orphans
         build_demo_site
-        generate_certs
+        if [ "$TLS_MODE" = "acme" ]; then
+            validate_acme_config
+            ensure_acme_cert
+        else
+            generate_certs
+        fi
         create_nginx_config
         ensure_kroki_core
         echo "Starting services with Docker Compose..."


### PR DESCRIPTION
## Summary

PR-7 of the [public-hosting plan](docs/public-hosting-plan-2026-06-12.md) (§4): real certificates for public deployments, with the self-signed closed-network default untouched (**byte-identical** generated config verified against main).

- **`TLS_MODE=acme`**: `start`/`restart` validate config (literal `^HOSTNAME=` line required in `.env` — the bash builtin is never trusted; localhost/dotless names rejected; `ACME_EMAIL` required) then issue via certbot standalone with `--key-type ecdsa` (mandatory: the nginx cipher list is ECDSA-only — a default RSA cert would fail every handshake). `ACME_STAGING=1` for dry-runs against the staging CA.
- **`docker-compose.acme.yml` overlay** (auto-applied in acme mode): nginx additionally publishes `:80 → :8080` for HTTP-01 challenges + 301 redirect, mounts certs read-only, and reloads every 6h to pick up renewals; a pinned `certbot/certbot:v4.0.0` sidecar renews via webroot every 12h.
- **HSTS** (`max-age=86400` initially — rollback-safe per sign-off, raise post-launch) folds into the shared `NGINX_SECURITY_HEADERS` fragment, so it lands at http level **and** inside the cached render location (verified count=2 — the cross-product bug the integration review caught).
- **Ops**: `scripts/check-cert-expiry.sh` daily cron backstop (alerts <21 days remaining via ntfy-compatible webhook — renewal runs at <30, so firing means renewal has been failing for ~9 days); `clean` preserves `./letsencrypt` (LE duplicate-cert limit is 5/week); hairpin-NAT fallback in service checks; `docs/acme-tls.md` with the 4-line `.env` diff, staging-first procedure, and rollback caveats.

Live ACME issuance is deliberately not exercised here — the public deployment is deferred; the launch checklist covers the staging dry-run when a domain exists.

## Verification

24/24 checks: selfsigned genconfig byte-identical to main; acme genconfig (`:8080` listener, challenge location, 301, LE paths, HSTS×2) passes `nginx -t` with dummy ECDSA certs, including the full public+acme bundle; compose overlay merge verified (both ports, 4 volumes, command replaced, certbot on the network); all five validation guards fire correctly; `genconfig` stays validation- and docker-free; cert-expiry script tested against 365-day (exit 0) and 5-day (exit 1 + webhook POST received) certs; shellcheck clean incl. `scripts/`; suites green (47 pytest / 58 bun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)