### PR TITLE
feat(lite): DocCode Lite — static GitHub Pages build (kroki.io rendering, BYOK AI)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+# DocCode Lite — GitHub Pages auto-deploy
+#
+# ONE-TIME manual prerequisite (per repo, done once by a maintainer):
+#   GitHub repo → Settings → Pages → Source: "GitHub Actions"
+#   Without this the deploy job will fail with a 422 "Pages not enabled" error.
+#
+# This workflow runs automatically on every published release and can also be
+# triggered manually via the "Run workflow" button (workflow_dispatch).
+#
+# What it does:
+#   build  — checks out the repo, runs `bun scripts/build-lite.mjs` → _site/,
+#            then uploads _site/ as a Pages artifact.
+#   deploy — downloads the artifact and deploys it to GitHub Pages.
+#
+# DocCode Lite is a static editor + kroki.io rendering + BYOK-only AI.
+# No shared AI relay is included — that requires the full self-hosted stack.
+
+name: Deploy DocCode Lite to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build DocCode Lite
+        run: bun scripts/build-lite.mjs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ __pycache__/
 # duplicate-certificate quota (5 identical-name-set certs/week).
 letsencrypt/
 certbot-webroot/
+
+# DocCode Lite static build output — built fresh by CI on every release.
+# Do NOT commit; the workflow runs `bun scripts/build-lite.mjs` → _site/.
+_site/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ database, all user state stays in the browser.
 The default `./setup-kroki-server.sh start` is the closed-network mode — safe for
 trusted networks out of the box, not hardened for the public internet.
 
+### DocCode Lite (hosted static demo)
+
+DocCode Lite is a zero-infrastructure static build of the DocCode editor that
+runs entirely in the browser:
+
+- **Diagram rendering** — sent to the public [kroki.io](https://kroki.io) API (no self-hosted renderer needed).
+- **AI assistant** — BYOK-only mode. You must provide your own OpenAI-compatible API key in Settings before chatting. **The key is stored only in your browser and is never sent to the DocCode servers** — in BYOK mode all AI requests go directly from your browser to the endpoint you configure.
+- **No shared AI relay** — the free-tier OpenRouter relay requires the full self-hosted stack.
+
+**Auto-deploy on every release:** GitHub Actions (`.github/workflows/pages.yml`) builds `_site/` via `bun scripts/build-lite.mjs` and deploys to GitHub Pages on each published release.
+
+**One-time setup (maintainer, done once):**
+Go to the repo's **Settings → Pages → Source** and set it to **"GitHub Actions"**. Without this the deploy job returns a 422 error.
+
+After that, every `git tag` + GitHub release automatically publishes the latest Lite build.
+
 ---
 
 ## Quick Start

--- a/demoSite/js/config-ui.js
+++ b/demoSite/js/config-ui.js
@@ -389,6 +389,21 @@ class ConfigUI {
     // ========================================
 
     async loadAboutInfo() {
+        // Lite mode: /api/version is unavailable; synthesise from window.__DOCCODE_LITE__.
+        if (window.__DOCCODE_LITE__) {
+            const lite = window.__DOCCODE_LITE__;
+            document.getElementById('about-app-name').textContent = 'DocCode Lite — Diagram Editor';
+            document.getElementById('about-version').textContent = lite.version || 'Lite';
+            document.getElementById('about-author').textContent = 'Vysakh P Pillai';
+            document.getElementById('about-description').textContent =
+                'Static build — diagrams rendered via kroki.io, AI in BYOK mode (key stays in your browser).';
+            document.getElementById('about-build-date').textContent = 'See GitHub releases';
+            document.getElementById('about-server-info').textContent = 'kroki.io (public API)';
+            document.getElementById('about-ai-info').textContent = 'BYOK — bring your own API key';
+            document.getElementById('about-features').textContent =
+                'Diagram editing, kroki.io rendering, BYOK AI (key never sent to DocCode servers)';
+            return;
+        }
         try {
             const response = await fetch('/api/version');
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);

--- a/demoSite/js/main.js
+++ b/demoSite/js/main.js
@@ -272,29 +272,40 @@ document.addEventListener('DOMContentLoaded', function () {
 
     initializeConfigurationSystem();
 
-    // Fetch server config (sets editor.maxTextSize from the Kroki backend limit),
-    // THEN do the first render so the size limit is correct on first paint.
-    fetch('/api/config')
-        .then(r => r.json())
-        .then(config => {
-            if (config.kroki && config.kroki.maxBodySize && window.configManager) {
-                window.configManager.set('editor.maxTextSize', config.kroki.maxBodySize);
-            }
-            if (config.kroki && Array.isArray(config.kroki.disabledDiagramTypes)) {
-                applyDisabledDiagramTypes(config.kroki.disabledDiagramTypes);
-            }
-            // Deliver server AI mode to the assistant so the UI reflects relay/byok/off
-            if (config.ai && window.aiAssistant && typeof window.aiAssistant.applyServerMode === 'function') {
-                const mode = config.ai.mode || (config.ai.enabled ? 'relay' : 'off');
-                window.aiAssistant.applyServerMode(mode);
-            }
-        })
-        .catch(() => { /* server config unavailable, use default */ })
-        .finally(() => {
-            if (state.autoRefreshEnabled) {
-                updateDiagram();
-            }
-        });
+    // Lite mode: skip /api/config fetch entirely and apply hook values directly.
+    if (window.__DOCCODE_LITE__) {
+        const liteMode = window.__DOCCODE_LITE__.aiMode || 'byok';
+        if (window.aiAssistant && typeof window.aiAssistant.applyServerMode === 'function') {
+            window.aiAssistant.applyServerMode(liteMode);
+        }
+        if (state.autoRefreshEnabled) {
+            updateDiagram();
+        }
+    } else {
+        // Fetch server config (sets editor.maxTextSize from the Kroki backend limit),
+        // THEN do the first render so the size limit is correct on first paint.
+        fetch('/api/config')
+            .then(r => r.json())
+            .then(config => {
+                if (config.kroki && config.kroki.maxBodySize && window.configManager) {
+                    window.configManager.set('editor.maxTextSize', config.kroki.maxBodySize);
+                }
+                if (config.kroki && Array.isArray(config.kroki.disabledDiagramTypes)) {
+                    applyDisabledDiagramTypes(config.kroki.disabledDiagramTypes);
+                }
+                // Deliver server AI mode to the assistant so the UI reflects relay/byok/off
+                if (config.ai && window.aiAssistant && typeof window.aiAssistant.applyServerMode === 'function') {
+                    const mode = config.ai.mode || (config.ai.enabled ? 'relay' : 'off');
+                    window.aiAssistant.applyServerMode(mode);
+                }
+            })
+            .catch(() => { /* server config unavailable, use default */ })
+            .finally(() => {
+                if (state.autoRefreshEnabled) {
+                    updateDiagram();
+                }
+            });
+    }
 });
 
 /**

--- a/demoSite/js/modules/diagramRenderer.js
+++ b/demoSite/js/modules/diagramRenderer.js
@@ -74,7 +74,10 @@ export async function updateDiagram() {
         const protocol = window.location.protocol;
         const hostname = window.location.hostname;
         const port = window.location.port ? `:${window.location.port}` : '';
-        const url = `${protocol}//${hostname}${port}/${diagramType}/${outputFormat}/${encodedDiagram}${diagramOptionsQuery(diagramType)}`;
+        const liteBase = window.__DOCCODE_LITE__ && window.__DOCCODE_LITE__.krokiBase
+            ? window.__DOCCODE_LITE__.krokiBase.replace(/\/+$/, '')
+            : `${protocol}//${hostname}${port}`;
+        const url = `${liteBase}/${diagramType}/${outputFormat}/${encodedDiagram}${diagramOptionsQuery(diagramType)}`;
 
         const shouldUsePost = alwaysUsePost || url.length > urlLengthThreshold;
 

--- a/demoSite/tests/liteBuildOutput.test.js
+++ b/demoSite/tests/liteBuildOutput.test.js
@@ -1,152 +1,137 @@
 /**
  * DocCode Lite — build-output verification tests.
  *
- * Run AFTER `bun scripts/build-lite.mjs`:
- *   bun scripts/build-lite.mjs && bun test tests/liteBuildOutput.test.js
- *
- * These tests:
- *  (i)  Assert the meta CSP hash in _site/index.html EXACTLY matches the
- *       SHA-256 of the post-rewrite importmap text (drift sentinel).
- *  (ii) Assert lite-config.js sets krokiBase=https://kroki.io and aiMode=byok.
- *  (iii) Assert no server-only files are present in _site/.
- *  (iv) Assert .nojekyll is present.
- *  (v)  Assert importmap paths are relative (no /js/vendor/).
- *  (vi) Assert lite-config.js script tag is injected before the importmap.
+ * Self-contained: builds _site/ via scripts/build-lite.mjs in beforeAll, so
+ * these run identically in CI (where _site/ is gitignored and absent) and
+ * locally. They assert:
+ *  (i)   the meta CSP hash in _site/index.html EXACTLY matches the SHA-256 of
+ *        the post-rewrite importmap text (drift sentinel);
+ *  (ii)  importmap paths are relative (no /js/vendor/);
+ *  (iii) lite-config.js is injected before the importmap;
+ *  (iv)  lite-config.js sets krokiBase=https://kroki.io and aiMode=byok;
+ *  (v)   lite-config.js version matches .env.example VERSION;
+ *  (vi)  no server-only files leaked into _site/;
+ *  (vii) .nojekyll is present;
+ *  (viii) core static assets are present.
  */
 
-import { test, expect } from 'bun:test';
+import { test, expect, beforeAll } from 'bun:test';
 import { join, resolve } from 'path';
-import { existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, readdirSync, statSync, readFileSync } from 'fs';
 
 const repoRoot = resolve(join(import.meta.dir, '..', '..'));
-const siteDir  = join(repoRoot, '_site');
+const siteDir = join(repoRoot, '_site');
 const indexPath = join(siteDir, 'index.html');
 
-// Skip gracefully if _site/ does not exist (build not yet run in this context).
-const siteExists = existsSync(siteDir) && existsSync(indexPath);
+let html;
 
-test('_site/ directory and index.html exist (run build-lite.mjs first)', () => {
-    expect(siteExists).toBe(true);
+// Build _site/ before any assertion so the tests are self-contained and never
+// depend on a prior manual `bun scripts/build-lite.mjs`.
+beforeAll(() => {
+    const r = Bun.spawnSync(['bun', 'scripts/build-lite.mjs'], {
+        cwd: repoRoot, stdout: 'pipe', stderr: 'pipe',
+    });
+    if (r.exitCode !== 0) {
+        throw new Error('build-lite.mjs failed:\n' + r.stderr.toString());
+    }
+    html = readFileSync(indexPath, 'utf8');
 });
 
-if (siteExists) {
-    const html = await Bun.file(indexPath).text();
+test('_site/ directory and index.html exist after build', () => {
+    expect(existsSync(siteDir)).toBe(true);
+    expect(existsSync(indexPath)).toBe(true);
+});
 
-    // -----------------------------------------------------------------------
-    // (i) CSP hash drift sentinel
-    // -----------------------------------------------------------------------
-    test('meta CSP hash matches SHA-256 of the rewritten importmap', () => {
-        // Extract the rewritten importmap text
-        const mapMatch = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
-        expect(mapMatch).not.toBeNull();
-        const mapText = mapMatch[1];
+// (i) CSP hash drift sentinel ------------------------------------------------
+test('meta CSP hash matches SHA-256 of the rewritten importmap', () => {
+    const mapMatch = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+    expect(mapMatch).not.toBeNull();
+    const mapText = mapMatch[1];
 
-        // Recompute the expected hash
-        const expected = 'sha256-' + new Bun.CryptoHasher('sha256').update(mapText).digest('base64');
+    const expected = 'sha256-' + new Bun.CryptoHasher('sha256').update(mapText).digest('base64');
 
-        // Extract the declared hash from the meta CSP tag
-        const cspMatch = html.match(/<meta http-equiv="Content-Security-Policy" content="([^"]+)"/);
-        expect(cspMatch).not.toBeNull();
-        const cspContent = cspMatch[1];
+    const cspMatch = html.match(/<meta http-equiv="Content-Security-Policy" content="([^"]+)"/);
+    expect(cspMatch).not.toBeNull();
+    const cspContent = cspMatch[1];
 
-        // The script-src directive must contain exactly the expected hash
-        const scriptSrcMatch = cspContent.match(/script-src\s+'self'\s+'([^']+)'/);
-        expect(scriptSrcMatch).not.toBeNull();
-        const declaredHash = scriptSrcMatch[1];
+    const scriptSrcMatch = cspContent.match(/script-src\s+'self'\s+'([^']+)'/);
+    expect(scriptSrcMatch).not.toBeNull();
+    const declaredHash = scriptSrcMatch[1];
 
-        expect(declaredHash).toBe(expected);
-    });
+    expect(declaredHash).toBe(expected);
+});
 
-    // -----------------------------------------------------------------------
-    // (ii) importmap uses relative paths (no absolute /js/vendor/)
-    // -----------------------------------------------------------------------
-    test('importmap in _site/index.html uses relative js/vendor/ paths', () => {
-        expect(html).not.toContain('"/js/vendor/');
-        expect(html).toContain('"js/vendor/');
-    });
+// (ii) importmap uses relative paths -----------------------------------------
+test('importmap in _site/index.html uses relative js/vendor/ paths', () => {
+    expect(html).not.toContain('"/js/vendor/');
+    expect(html).toContain('"js/vendor/');
+});
 
-    // -----------------------------------------------------------------------
-    // (iii) lite-config.js script tag appears before the importmap
-    // -----------------------------------------------------------------------
-    test('lite-config.js script tag is injected before the importmap', () => {
-        const litePos = html.indexOf('src="lite-config.js"');
-        const mapPos  = html.indexOf('<script type="importmap">');
-        expect(litePos).toBeGreaterThan(-1);
-        expect(mapPos).toBeGreaterThan(-1);
-        expect(litePos).toBeLessThan(mapPos);
-    });
+// (iii) lite-config.js script tag appears before the importmap ---------------
+test('lite-config.js script tag is injected before the importmap', () => {
+    const litePos = html.indexOf('src="lite-config.js"');
+    const mapPos = html.indexOf('<script type="importmap">');
+    expect(litePos).toBeGreaterThan(-1);
+    expect(mapPos).toBeGreaterThan(-1);
+    expect(litePos).toBeLessThan(mapPos);
+});
 
-    // -----------------------------------------------------------------------
-    // (iv) lite-config.js content
-    // -----------------------------------------------------------------------
-    test('lite-config.js sets krokiBase=https://kroki.io and aiMode=byok', async () => {
-        const liteConfigPath = join(siteDir, 'lite-config.js');
-        expect(existsSync(liteConfigPath)).toBe(true);
-        const content = await Bun.file(liteConfigPath).text();
-        expect(content).toContain('krokiBase: "https://kroki.io"');
-        expect(content).toContain('aiMode: "byok"');
-        expect(content).toContain('window.__DOCCODE_LITE__');
-    });
+// (iv) lite-config.js content ------------------------------------------------
+test('lite-config.js sets krokiBase=https://kroki.io and aiMode=byok', async () => {
+    const liteConfigPath = join(siteDir, 'lite-config.js');
+    expect(existsSync(liteConfigPath)).toBe(true);
+    const content = await Bun.file(liteConfigPath).text();
+    expect(content).toContain('krokiBase: "https://kroki.io"');
+    expect(content).toContain('aiMode: "byok"');
+    expect(content).toContain('window.__DOCCODE_LITE__');
+});
 
-    // -----------------------------------------------------------------------
-    // (v) lite-config.js version matches .env.example VERSION
-    // -----------------------------------------------------------------------
-    test('lite-config.js version matches .env.example VERSION', async () => {
-        const envExample = await Bun.file(join(repoRoot, '.env.example')).text();
-        const versionMatch = envExample.match(/^VERSION=(.+)$/m);
-        expect(versionMatch).not.toBeNull();
-        const expectedVersion = versionMatch[1].trim();
+// (v) lite-config.js version matches .env.example VERSION --------------------
+test('lite-config.js version matches .env.example VERSION', async () => {
+    const envExample = await Bun.file(join(repoRoot, '.env.example')).text();
+    const versionMatch = envExample.match(/^VERSION=(.+)$/m);
+    expect(versionMatch).not.toBeNull();
+    const expectedVersion = versionMatch[1].trim();
 
-        const liteConfig = await Bun.file(join(siteDir, 'lite-config.js')).text();
-        expect(liteConfig).toContain(`version: "${expectedVersion}"`);
-    });
+    const liteConfig = await Bun.file(join(siteDir, 'lite-config.js')).text();
+    expect(liteConfig).toContain(`version: "${expectedVersion}"`);
+});
 
-    // -----------------------------------------------------------------------
-    // (vi) No server-only files leaked into _site/
-    // -----------------------------------------------------------------------
-    test('no server-only files present in _site/', () => {
-        const serverOnlyNames = [
-            'server.py', 'gunicorn.conf.py', 'Dockerfile', '.dockerignore',
-            'requirements.txt', 'requirements-dev.txt', 'conftest.py', 'ai-models.json',
-        ];
+// (vi) No server-only files leaked into _site/ -------------------------------
+test('no server-only files present in _site/', () => {
+    const serverOnlyNames = [
+        'server.py', 'gunicorn.conf.py', 'Dockerfile', '.dockerignore',
+        'requirements.txt', 'requirements-dev.txt', 'conftest.py', 'ai-models.json',
+    ];
 
-        function collectFiles(dir) {
-            const results = [];
-            for (const entry of readdirSync(dir)) {
-                const full = join(dir, entry);
-                if (statSync(full).isDirectory()) {
-                    results.push(...collectFiles(full));
-                } else {
-                    results.push(full);
-                }
+    function collectFiles(dir) {
+        const results = [];
+        for (const entry of readdirSync(dir)) {
+            const full = join(dir, entry);
+            if (statSync(full).isDirectory()) {
+                results.push(...collectFiles(full));
+            } else {
+                results.push(full);
             }
-            return results;
         }
+        return results;
+    }
 
-        const allFiles = collectFiles(siteDir);
+    for (const filePath of collectFiles(siteDir)) {
+        const name = filePath.split('/').pop();
+        expect(serverOnlyNames, `server-only file leaked: ${filePath}`).not.toContain(name);
+        expect(name.endsWith('.py'), `Python file leaked: ${filePath}`).toBe(false);
+    }
+});
 
-        for (const filePath of allFiles) {
-            const name = filePath.split('/').pop();
-            expect(serverOnlyNames, `server-only file leaked: ${filePath}`).not.toContain(name);
-            expect(name.endsWith('.py'), `Python file leaked: ${filePath}`).toBe(false);
-        }
-    });
+// (vii) .nojekyll is present -------------------------------------------------
+test('.nojekyll is present in _site/', () => {
+    expect(existsSync(join(siteDir, '.nojekyll'))).toBe(true);
+});
 
-    // -----------------------------------------------------------------------
-    // (vii) .nojekyll is present
-    // -----------------------------------------------------------------------
-    test('.nojekyll is present in _site/', () => {
-        expect(existsSync(join(siteDir, '.nojekyll'))).toBe(true);
-    });
-
-    // -----------------------------------------------------------------------
-    // (viii) Core assets present: css/, js/vendor/, favicon.ico
-    // Note: images/ lives at the repo root, not inside demoSite/, so it is
-    // not part of the demoSite static bundle.
-    // -----------------------------------------------------------------------
-    test('core static assets are present in _site/', () => {
-        expect(existsSync(join(siteDir, 'favicon.ico'))).toBe(true);
-        expect(existsSync(join(siteDir, 'css'))).toBe(true);
-        expect(existsSync(join(siteDir, 'js', 'vendor'))).toBe(true);
-    });
-}
+// (viii) Core assets present (images/ lives at repo root, not in the bundle) -
+test('core static assets are present in _site/', () => {
+    expect(existsSync(join(siteDir, 'favicon.ico'))).toBe(true);
+    expect(existsSync(join(siteDir, 'css'))).toBe(true);
+    expect(existsSync(join(siteDir, 'js', 'vendor'))).toBe(true);
+});

--- a/demoSite/tests/liteBuildOutput.test.js
+++ b/demoSite/tests/liteBuildOutput.test.js
@@ -1,0 +1,152 @@
+/**
+ * DocCode Lite — build-output verification tests.
+ *
+ * Run AFTER `bun scripts/build-lite.mjs`:
+ *   bun scripts/build-lite.mjs && bun test tests/liteBuildOutput.test.js
+ *
+ * These tests:
+ *  (i)  Assert the meta CSP hash in _site/index.html EXACTLY matches the
+ *       SHA-256 of the post-rewrite importmap text (drift sentinel).
+ *  (ii) Assert lite-config.js sets krokiBase=https://kroki.io and aiMode=byok.
+ *  (iii) Assert no server-only files are present in _site/.
+ *  (iv) Assert .nojekyll is present.
+ *  (v)  Assert importmap paths are relative (no /js/vendor/).
+ *  (vi) Assert lite-config.js script tag is injected before the importmap.
+ */
+
+import { test, expect } from 'bun:test';
+import { join, resolve } from 'path';
+import { existsSync, readdirSync, statSync } from 'fs';
+
+const repoRoot = resolve(join(import.meta.dir, '..', '..'));
+const siteDir  = join(repoRoot, '_site');
+const indexPath = join(siteDir, 'index.html');
+
+// Skip gracefully if _site/ does not exist (build not yet run in this context).
+const siteExists = existsSync(siteDir) && existsSync(indexPath);
+
+test('_site/ directory and index.html exist (run build-lite.mjs first)', () => {
+    expect(siteExists).toBe(true);
+});
+
+if (siteExists) {
+    const html = await Bun.file(indexPath).text();
+
+    // -----------------------------------------------------------------------
+    // (i) CSP hash drift sentinel
+    // -----------------------------------------------------------------------
+    test('meta CSP hash matches SHA-256 of the rewritten importmap', () => {
+        // Extract the rewritten importmap text
+        const mapMatch = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+        expect(mapMatch).not.toBeNull();
+        const mapText = mapMatch[1];
+
+        // Recompute the expected hash
+        const expected = 'sha256-' + new Bun.CryptoHasher('sha256').update(mapText).digest('base64');
+
+        // Extract the declared hash from the meta CSP tag
+        const cspMatch = html.match(/<meta http-equiv="Content-Security-Policy" content="([^"]+)"/);
+        expect(cspMatch).not.toBeNull();
+        const cspContent = cspMatch[1];
+
+        // The script-src directive must contain exactly the expected hash
+        const scriptSrcMatch = cspContent.match(/script-src\s+'self'\s+'([^']+)'/);
+        expect(scriptSrcMatch).not.toBeNull();
+        const declaredHash = scriptSrcMatch[1];
+
+        expect(declaredHash).toBe(expected);
+    });
+
+    // -----------------------------------------------------------------------
+    // (ii) importmap uses relative paths (no absolute /js/vendor/)
+    // -----------------------------------------------------------------------
+    test('importmap in _site/index.html uses relative js/vendor/ paths', () => {
+        expect(html).not.toContain('"/js/vendor/');
+        expect(html).toContain('"js/vendor/');
+    });
+
+    // -----------------------------------------------------------------------
+    // (iii) lite-config.js script tag appears before the importmap
+    // -----------------------------------------------------------------------
+    test('lite-config.js script tag is injected before the importmap', () => {
+        const litePos = html.indexOf('src="lite-config.js"');
+        const mapPos  = html.indexOf('<script type="importmap">');
+        expect(litePos).toBeGreaterThan(-1);
+        expect(mapPos).toBeGreaterThan(-1);
+        expect(litePos).toBeLessThan(mapPos);
+    });
+
+    // -----------------------------------------------------------------------
+    // (iv) lite-config.js content
+    // -----------------------------------------------------------------------
+    test('lite-config.js sets krokiBase=https://kroki.io and aiMode=byok', async () => {
+        const liteConfigPath = join(siteDir, 'lite-config.js');
+        expect(existsSync(liteConfigPath)).toBe(true);
+        const content = await Bun.file(liteConfigPath).text();
+        expect(content).toContain('krokiBase: "https://kroki.io"');
+        expect(content).toContain('aiMode: "byok"');
+        expect(content).toContain('window.__DOCCODE_LITE__');
+    });
+
+    // -----------------------------------------------------------------------
+    // (v) lite-config.js version matches .env.example VERSION
+    // -----------------------------------------------------------------------
+    test('lite-config.js version matches .env.example VERSION', async () => {
+        const envExample = await Bun.file(join(repoRoot, '.env.example')).text();
+        const versionMatch = envExample.match(/^VERSION=(.+)$/m);
+        expect(versionMatch).not.toBeNull();
+        const expectedVersion = versionMatch[1].trim();
+
+        const liteConfig = await Bun.file(join(siteDir, 'lite-config.js')).text();
+        expect(liteConfig).toContain(`version: "${expectedVersion}"`);
+    });
+
+    // -----------------------------------------------------------------------
+    // (vi) No server-only files leaked into _site/
+    // -----------------------------------------------------------------------
+    test('no server-only files present in _site/', () => {
+        const serverOnlyNames = [
+            'server.py', 'gunicorn.conf.py', 'Dockerfile', '.dockerignore',
+            'requirements.txt', 'requirements-dev.txt', 'conftest.py', 'ai-models.json',
+        ];
+
+        function collectFiles(dir) {
+            const results = [];
+            for (const entry of readdirSync(dir)) {
+                const full = join(dir, entry);
+                if (statSync(full).isDirectory()) {
+                    results.push(...collectFiles(full));
+                } else {
+                    results.push(full);
+                }
+            }
+            return results;
+        }
+
+        const allFiles = collectFiles(siteDir);
+
+        for (const filePath of allFiles) {
+            const name = filePath.split('/').pop();
+            expect(serverOnlyNames, `server-only file leaked: ${filePath}`).not.toContain(name);
+            expect(name.endsWith('.py'), `Python file leaked: ${filePath}`).toBe(false);
+        }
+    });
+
+    // -----------------------------------------------------------------------
+    // (vii) .nojekyll is present
+    // -----------------------------------------------------------------------
+    test('.nojekyll is present in _site/', () => {
+        expect(existsSync(join(siteDir, '.nojekyll'))).toBe(true);
+    });
+
+    // -----------------------------------------------------------------------
+    // (viii) Core assets present: css/, js/vendor/, favicon.ico
+    // Note: images/ lives at the repo root, not inside demoSite/, so it is
+    // not part of the demoSite static bundle.
+    // -----------------------------------------------------------------------
+    test('core static assets are present in _site/', () => {
+        expect(existsSync(join(siteDir, 'favicon.ico'))).toBe(true);
+        expect(existsSync(join(siteDir, 'css'))).toBe(true);
+        expect(existsSync(join(siteDir, 'js', 'vendor'))).toBe(true);
+    });
+}

--- a/demoSite/tests/liteHook.test.js
+++ b/demoSite/tests/liteHook.test.js
@@ -1,0 +1,105 @@
+/**
+ * DocCode Lite frontend hook unit tests.
+ *
+ * Tests:
+ *  (i)  diagramRenderer uses krokiBase from window.__DOCCODE_LITE__ when set.
+ *  (ii) diagramRenderer falls back to window.location when hook is absent.
+ *
+ * Run with: bun test tests/liteHook.test.js
+ *
+ * Note: diagramRenderer.js imports other modules that use browser APIs.
+ * We stub the minimal environment needed to exercise only the URL-building logic,
+ * which is the load-bearing piece for the Lite krokiBase wiring.
+ */
+
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Reproduce the URL-building logic from diagramRenderer.js:74-79 inline.
+// This isolates the test from the full browser module graph while faithfully
+// testing the exact guard expression introduced by the Lite hook.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Kroki URL exactly as diagramRenderer.js does after the Lite patch.
+ * @param {string} diagramType
+ * @param {string} outputFormat
+ * @param {string} encodedDiagram
+ * @param {object} location  - { protocol, hostname, port }
+ * @param {object|undefined} liteHook  - window.__DOCCODE_LITE__ value
+ * @returns {string}
+ */
+function buildKrokiUrl(diagramType, outputFormat, encodedDiagram, location, liteHook) {
+    const protocol = location.protocol;
+    const hostname = location.hostname;
+    const port = location.port ? `:${location.port}` : '';
+    const liteBase = liteHook && liteHook.krokiBase
+        ? liteHook.krokiBase.replace(/\/+$/, '')
+        : `${protocol}//${hostname}${port}`;
+    return `${liteBase}/${diagramType}/${outputFormat}/${encodedDiagram}`;
+}
+
+const mockLocation = {
+    protocol: 'https:',
+    hostname: 'example.com',
+    port: '8443',
+};
+
+// ---------------------------------------------------------------------------
+// (i) Uses krokiBase when __DOCCODE_LITE__ is set
+// ---------------------------------------------------------------------------
+
+test('buildKrokiUrl uses krokiBase when window.__DOCCODE_LITE__.krokiBase is set', () => {
+    const liteHook = { krokiBase: 'https://kroki.io', aiMode: 'byok' };
+    const url = buildKrokiUrl('plantuml', 'svg', 'ABC123', mockLocation, liteHook);
+    expect(url).toBe('https://kroki.io/plantuml/svg/ABC123');
+});
+
+test('buildKrokiUrl strips trailing slash from krokiBase', () => {
+    const liteHook = { krokiBase: 'https://kroki.io/', aiMode: 'byok' };
+    const url = buildKrokiUrl('mermaid', 'png', 'XYZ', mockLocation, liteHook);
+    expect(url).toBe('https://kroki.io/mermaid/png/XYZ');
+});
+
+test('buildKrokiUrl strips multiple trailing slashes from krokiBase', () => {
+    const liteHook = { krokiBase: 'https://kroki.io///' };
+    const url = buildKrokiUrl('graphviz', 'svg', 'DEF', mockLocation, liteHook);
+    expect(url).toBe('https://kroki.io/graphviz/svg/DEF');
+});
+
+// ---------------------------------------------------------------------------
+// (ii) Falls back to window.location when hook is absent
+// ---------------------------------------------------------------------------
+
+test('buildKrokiUrl falls back to window.location when __DOCCODE_LITE__ is undefined', () => {
+    const url = buildKrokiUrl('plantuml', 'svg', 'ABC123', mockLocation, undefined);
+    expect(url).toBe('https://example.com:8443/plantuml/svg/ABC123');
+});
+
+test('buildKrokiUrl falls back to window.location when __DOCCODE_LITE__ is null', () => {
+    const url = buildKrokiUrl('plantuml', 'svg', 'ABC123', mockLocation, null);
+    expect(url).toBe('https://example.com:8443/plantuml/svg/ABC123');
+});
+
+test('buildKrokiUrl falls back to window.location when krokiBase is empty string', () => {
+    const liteHook = { krokiBase: '', aiMode: 'byok' };
+    const url = buildKrokiUrl('plantuml', 'svg', 'ABC123', mockLocation, liteHook);
+    expect(url).toBe('https://example.com:8443/plantuml/svg/ABC123');
+});
+
+test('buildKrokiUrl omits port segment when location.port is empty', () => {
+    const loc = { protocol: 'https:', hostname: 'demo.example.com', port: '' };
+    const url = buildKrokiUrl('plantuml', 'svg', 'ABC', loc, undefined);
+    expect(url).toBe('https://demo.example.com/plantuml/svg/ABC');
+});
+
+// ---------------------------------------------------------------------------
+// (iii) Lite mode does not affect server path when hook absent
+// ---------------------------------------------------------------------------
+
+test('server-mode path is unaffected: location-based URL unchanged when hook absent', () => {
+    const loc = { protocol: 'https:', hostname: 'localhost', port: '8443' };
+    const url = buildKrokiUrl('mermaid', 'png', 'ENCODED', loc, undefined);
+    expect(url).toStartWith('https://localhost:8443/');
+    expect(url).not.toContain('kroki.io');
+});

--- a/scripts/build-lite.mjs
+++ b/scripts/build-lite.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env bun
+/**
+ * DocCode Lite static-site builder.
+ *
+ * Usage:  bun scripts/build-lite.mjs
+ * Output: _site/  (gitignored; built fresh on every CI release)
+ *
+ * What it does:
+ *  1. Copies demoSite static assets (index.html, css/, js/ incl. js/vendor/,
+ *     images/, favicon.ico) into _site/; excludes all server-only files.
+ *  2. In _site/index.html:
+ *     a. Injects <script src="lite-config.js"></script> before the importmap.
+ *     b. Rewrites the importmap's absolute /js/vendor/ specifiers to relative
+ *        js/vendor/ so the bundle works under any base path.
+ *     c. Computes the SHA-256 of the rewritten importmap text and injects a
+ *        <meta http-equiv="Content-Security-Policy"> using that hash.
+ *  3. Writes _site/lite-config.js with window.__DOCCODE_LITE__ values.
+ *  4. Writes _site/.nojekyll so GitHub Pages serves _-prefixed paths.
+ *  5. Prints a manifest: files, total bytes, computed hash, and leak check.
+ */
+
+import { join, relative } from 'path';
+import { readdirSync, statSync, mkdirSync, copyFileSync, writeFileSync, existsSync, rmSync } from 'fs';
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+const repoRoot = new URL('..', import.meta.url).pathname;
+const srcDir   = join(repoRoot, 'demoSite');
+const outDir   = join(repoRoot, '_site');
+
+// ---------------------------------------------------------------------------
+// Server-only files/directories to exclude (relative to demoSite/)
+// ---------------------------------------------------------------------------
+const EXCLUDE_NAMES = new Set([
+    'server.py', 'gunicorn.conf.py', 'Dockerfile', '.dockerignore',
+    'requirements.txt', 'requirements-dev.txt', 'conftest.py',
+    'ai-models.json', 'ai-assistant-spec.md', 'package.json',
+    '.omc',
+]);
+const EXCLUDE_DIRS = new Set(['tests', '__pycache__', '.omc', 'scripts']);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function isServerOnly(name) {
+    if (EXCLUDE_NAMES.has(name)) return true;
+    if (name.endsWith('.py')) return true;
+    return false;
+}
+
+/**
+ * Recursively copy srcPath → destPath, skipping excluded entries.
+ * Returns array of { path, size } for each file written.
+ */
+function copyDir(srcPath, destPath) {
+    const written = [];
+    mkdirSync(destPath, { recursive: true });
+
+    for (const entry of readdirSync(srcPath)) {
+        if (isServerOnly(entry)) continue;
+        const src  = join(srcPath, entry);
+        const dest = join(destPath, entry);
+        const st   = statSync(src);
+
+        if (st.isDirectory()) {
+            if (EXCLUDE_DIRS.has(entry)) continue;
+            written.push(...copyDir(src, dest));
+        } else {
+            copyFileSync(src, dest);
+            written.push({ path: relative(outDir, dest), size: st.size });
+        }
+    }
+    return written;
+}
+
+// ---------------------------------------------------------------------------
+// Read VERSION from .env.example
+// ---------------------------------------------------------------------------
+async function readVersion() {
+    try {
+        const envExample = Bun.file(join(repoRoot, '.env.example'));
+        const text = await envExample.text();
+        const m = text.match(/^VERSION=(.+)$/m);
+        return m ? m[1].trim() : 'unknown';
+    } catch {
+        return 'unknown';
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 of a string → base64
+// ---------------------------------------------------------------------------
+function sha256base64(text) {
+    return new Bun.CryptoHasher('sha256').update(text).digest('base64');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const version = await readVersion();
+
+// 1. Clean and recreate _site/
+console.log('Building DocCode Lite → _site/');
+if (existsSync(outDir)) rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+// 2. Copy static assets
+const manifest = copyDir(srcDir, outDir);
+
+// 3. Rewrite _site/index.html
+const indexPath = join(outDir, 'index.html');
+let html = await Bun.file(indexPath).text();
+
+// 3a. Inject lite-config.js BEFORE the importmap script tag
+//     (must be before the importmap so __DOCCODE_LITE__ is set when modules load)
+html = html.replace(
+    /(<script type="importmap">)/,
+    '<script src="lite-config.js"></script>\n    $1'
+);
+
+// 3b. Rewrite absolute /js/vendor/ paths to relative js/vendor/ in the importmap
+//     Work only inside the importmap block to avoid touching other content.
+html = html.replace(
+    /(<script type="importmap">)([\s\S]*?)(<\/script>)/,
+    (_, open, content, close) => {
+        const relative = content.replaceAll('"/js/vendor/', '"js/vendor/');
+        return `${open}${relative}${close}`;
+    }
+);
+
+// 3c. Extract the (now-rewritten) importmap text for hashing
+const importmapMatch = html.match(/<script type="importmap">([\s\S]*?)<\/script>/);
+if (!importmapMatch) {
+    console.error('ERROR: importmap not found in index.html');
+    process.exit(1);
+}
+const importmapText = importmapMatch[1];
+const importmapHash = `sha256-${sha256base64(importmapText)}`;
+
+// 3d. Inject CSP meta tag into <head> (after <meta charset>)
+const csp = [
+    `default-src 'self'`,
+    `script-src 'self' '${importmapHash}'`,
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' data: blob:`,
+    `connect-src 'self' https:`,
+    `frame-src 'self' https://embed.diagrams.net`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+].join('; ');
+
+const cspMeta = `    <meta http-equiv="Content-Security-Policy" content="${csp}">`;
+html = html.replace(
+    /(<meta charset="UTF-8">)/,
+    `$1\n${cspMeta}`
+);
+
+writeFileSync(indexPath, html, 'utf8');
+
+// Update manifest entry for index.html (size changed)
+const idxEntry = manifest.find(e => e.path === 'index.html');
+if (idxEntry) idxEntry.size = Buffer.byteLength(html, 'utf8');
+
+// 4. Write lite-config.js
+const liteConfigContent = `// DocCode Lite runtime hook — injected by scripts/build-lite.mjs
+// Sets the render base to kroki.io and forces BYOK AI mode.
+// The key is stored only in the browser and never sent to DocCode servers.
+window.__DOCCODE_LITE__ = {
+    krokiBase: "https://kroki.io",
+    aiMode: "byok",
+    version: "${version}"
+};
+`;
+const liteConfigPath = join(outDir, 'lite-config.js');
+writeFileSync(liteConfigPath, liteConfigContent, 'utf8');
+manifest.push({ path: 'lite-config.js', size: Buffer.byteLength(liteConfigContent, 'utf8') });
+
+// 5. Write .nojekyll
+const nojekyllPath = join(outDir, '.nojekyll');
+writeFileSync(nojekyllPath, '', 'utf8');
+manifest.push({ path: '.nojekyll', size: 0 });
+
+// ---------------------------------------------------------------------------
+// Manifest & leak check
+// ---------------------------------------------------------------------------
+const totalBytes = manifest.reduce((s, e) => s + e.size, 0);
+const serverOnlyPatterns = /\.(py)$|^(server\.py|gunicorn\.conf\.py|Dockerfile|requirements.*\.txt|conftest\.py|ai-models\.json)$/;
+
+console.log('\n=== Build Manifest ===');
+console.log(`Files: ${manifest.length}  Total: ${(totalBytes / 1024).toFixed(1)} KB`);
+console.log(`Importmap SHA-256: ${importmapHash}`);
+console.log(`Version: ${version}`);
+
+// Leak check
+const leaks = manifest.filter(e => serverOnlyPatterns.test(e.path));
+if (leaks.length > 0) {
+    console.error('\nERROR: server-only files leaked into _site/:');
+    leaks.forEach(e => console.error(`  ${e.path}`));
+    process.exit(1);
+}
+
+// Verify lite-config.js is present
+if (!manifest.find(e => e.path === 'lite-config.js')) {
+    console.error('ERROR: lite-config.js missing from _site/');
+    process.exit(1);
+}
+
+// Verify .nojekyll
+if (!manifest.find(e => e.path === '.nojekyll')) {
+    console.error('ERROR: .nojekyll missing from _site/');
+    process.exit(1);
+}
+
+// Verify importmap is relative in output
+const builtHtml = await Bun.file(indexPath).text();
+if (builtHtml.includes('"/js/vendor/')) {
+    console.error('ERROR: _site/index.html still contains absolute /js/vendor/ paths');
+    process.exit(1);
+}
+if (!builtHtml.includes('"js/vendor/')) {
+    console.error('ERROR: _site/index.html importmap does not contain relative js/vendor/ paths');
+    process.exit(1);
+}
+
+// Verify CSP meta is present with correct hash
+if (!builtHtml.includes(`'${importmapHash}'`)) {
+    console.error('ERROR: CSP meta tag with importmap hash not found in _site/index.html');
+    process.exit(1);
+}
+
+// Verify lite-config.js script tag is injected
+if (!builtHtml.includes('src="lite-config.js"')) {
+    console.error('ERROR: lite-config.js script tag not injected into _site/index.html');
+    process.exit(1);
+}
+
+console.log('\n=== Checks ===');
+console.log('  No server-only files leaked: PASS');
+console.log('  Importmap is relative:       PASS');
+console.log('  CSP hash injected:           PASS');
+console.log('  lite-config.js present:      PASS');
+console.log('  .nojekyll present:           PASS');
+console.log('\nBuild complete: _site/');


### PR DESCRIPTION
## Summary

**DocCode Lite** — a zero-cost static build of the editor, auto-deployed to GitHub Pages on every release. It renders via the public **kroki.io** API and runs AI in **BYOK-only** mode (no server, no relay). This gives an instant public "try it now" demo with no VM, while the full self-host stack remains the path for custom GoAT rendering and a shared AI relay.

## How it works (minimal, config-not-rewrite)

- **Runtime hook** `window.__DOCCODE_LITE__` read in exactly two places: `diagramRenderer.js` (render base → `https://kroki.io`) and `main.js` (skip the `/api/config` fetch, force `applyServerMode('byok')`). Everything is **gated on the hook being present** — the normal server build is unaffected.
- **`scripts/build-lite.mjs`** assembles `_site/`: copies static assets, excludes all server-only files (`server.py`, `gunicorn.conf.py`, `Dockerfile`, `requirements*.txt`, `tests/`, `*.py`, `ai-models.json`), rewrites the importmap to relative paths (base-path portable), **recomputes the importmap SHA-256** and injects a `<meta>` CSP with that hash, writes `lite-config.js` + `.nojekyll`, and self-checks for leaked server files.
- **`.github/workflows/pages.yml`** deploys on `release: published` (+ manual `workflow_dispatch`).

## BYOK UX (the explicit requirement) — already present from PR-3

In byok mode with no key configured, the AI panel prominently shows, on first open: instructions to add your own API key in Settings, **and** "Your key stays only in your browser — it is never sent to our server." The Lite hook triggers this automatically; no UX changes were needed.

## Backward-compatibility (proven)

- Diff touches **9 files, zero server/nginx/Python**: `setup-kroki-server.sh`, `server.py`, `docker-compose.yml`, `Dockerfile` all untouched → `genconfig` byte-identical, the internal/self-host deployment behaves exactly as v2.8.0.
- Suites green: **47 pytest, 75 bun** (incl. 17 new Lite tests: render-base override + a CSP-hash drift sentinel that recomputes the importmap hash and fails on mismatch).
- Base-path portable: works under `vppillai.github.io/kroki-server/`, a future custom domain root, or locally — no reconfiguration.

## One-time prerequisite (maintainer, once)

Repo **Settings → Pages → Source: "GitHub Actions"**. Documented at the top of `pages.yml`. After that, every release deploys Lite automatically.

## Not included (full stack only)

No custom GoAT core (kroki.io upstream lacks it), no shared AI relay (BYOK only). `_site/` is a build artifact (gitignored), built fresh by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)