### PR TITLE
fix(lite): valid relative importmap, font CSP, favicon, Node24 actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -45,7 +45,7 @@ jobs:
         run: bun scripts/build-lite.mjs
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/demoSite/index.html
+++ b/demoSite/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Vysakh P Pillai">
     <title>Doccode Diagram Editor</title>
+    <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/config.css">
     <link rel="stylesheet" href="css/ai-assistant.css">

--- a/demoSite/tests/liteBuildOutput.test.js
+++ b/demoSite/tests/liteBuildOutput.test.js
@@ -62,9 +62,9 @@ test('meta CSP hash matches SHA-256 of the rewritten importmap', () => {
 });
 
 // (ii) importmap uses relative paths -----------------------------------------
-test('importmap in _site/index.html uses relative js/vendor/ paths', () => {
+test('importmap in _site/index.html uses relative ./js/vendor/ paths', () => {
     expect(html).not.toContain('"/js/vendor/');
-    expect(html).toContain('"js/vendor/');
+    expect(html).toContain('"./js/vendor/');
 });
 
 // (iii) lite-config.js script tag appears before the importmap ---------------

--- a/scripts/build-lite.mjs
+++ b/scripts/build-lite.mjs
@@ -119,13 +119,16 @@ html = html.replace(
     '<script src="lite-config.js"></script>\n    $1'
 );
 
-// 3b. Rewrite absolute /js/vendor/ paths to relative js/vendor/ in the importmap
-//     Work only inside the importmap block to avoid touching other content.
+// 3b. Rewrite absolute /js/vendor/ paths to relative ./js/vendor/ in the importmap.
+//     Import-map addresses MUST be a URL or begin with /, ./, or ../ — a bare
+//     "js/vendor/x.js" is parsed as a bare specifier and ignored by the browser,
+//     breaking module resolution. The leading ./ makes the map resolve correctly
+//     under any base path (e.g. the /kroki-server/ project-pages subpath).
 html = html.replace(
     /(<script type="importmap">)([\s\S]*?)(<\/script>)/,
     (_, open, content, close) => {
-        const relative = content.replaceAll('"/js/vendor/', '"js/vendor/');
-        return `${open}${relative}${close}`;
+        const rel = content.replaceAll('"/js/vendor/', '"./js/vendor/');
+        return `${open}${rel}${close}`;
     }
 );
 
@@ -142,7 +145,8 @@ const importmapHash = `sha256-${sha256base64(importmapText)}`;
 const csp = [
     `default-src 'self'`,
     `script-src 'self' '${importmapHash}'`,
-    `style-src 'self' 'unsafe-inline'`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+    `font-src 'self' https://fonts.gstatic.com`,
     `img-src 'self' data: blob:`,
     `connect-src 'self' https:`,
     `frame-src 'self' https://embed.diagrams.net`,
@@ -218,8 +222,8 @@ if (builtHtml.includes('"/js/vendor/')) {
     console.error('ERROR: _site/index.html still contains absolute /js/vendor/ paths');
     process.exit(1);
 }
-if (!builtHtml.includes('"js/vendor/')) {
-    console.error('ERROR: _site/index.html importmap does not contain relative js/vendor/ paths');
+if (!builtHtml.includes('"./js/vendor/')) {
+    console.error('ERROR: _site/index.html importmap does not contain relative ./js/vendor/ paths');
     process.exit(1);
 }
 


### PR DESCRIPTION
Fixes four issues found testing the live DocCode Lite demo in a browser.

1. **Importmap (critical, editor was broken):** the build rewrote `/js/vendor/` → `js/vendor/`, but an import-map *address* must be a URL or begin with `/`, `./`, or `../` — a bare `js/vendor/x.js` is a *bare specifier* and is ignored, so CodeMirror + pako failed to resolve (`Failed to resolve module specifier "pako"`). Now rewrites to `./js/vendor/`, valid under any base path. The CSP hash is recomputed from the corrected importmap automatically.
2. **Google Fonts blocked by CSP:** `css/base.css` `@import`s `fonts.googleapis.com`. Added it to `style-src` and added `font-src 'self' https://fonts.gstatic.com`.
3. **favicon 404:** added an explicit relative `<link rel="icon" href="favicon.ico">` so it resolves under the `/kroki-server/` subpath (the browser was defaulting to the domain root).
4. **Workflow deprecation:** bumped `actions/checkout@v6`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5` (Node 24 — clears the Node 20 deprecation warning).

Verified: build produces `./js/vendor/` (0 absolute leftovers), CSP carries both font allowances, favicon link present, full suite 75/0 (the build-output test self-builds `_site/` and asserts the `./` importmap + hash match). Backward-compatible: the favicon link is harmless to the server build; no server/nginx/Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)