### PR TITLE
fix(csp): delegated AI message buttons + Lite API gating + favicon

### DIFF
--- a/demoSite/js/ai-assistant.js
+++ b/demoSite/js/ai-assistant.js
@@ -101,6 +101,17 @@ class AIAssistant {
         this.chatWindow.querySelector('.ai-chat-settings').addEventListener('click', () => this.openSettings());
         this.chatWindow.querySelector('.ai-model-indicator').addEventListener('click', () => this.openAISettings());
 
+        // Delegated handler for buttons injected into system messages via innerHTML.
+        // The strict CSP (script-src has no 'unsafe-inline') blocks inline onclick=
+        // attributes, so message buttons declare data-ai-action and are wired here.
+        this.chatMessages.addEventListener('click', (e) => {
+            const el = e.target.closest('[data-ai-action]');
+            if (!el) return;
+            const action = el.getAttribute('data-ai-action');
+            if (action === 'open-settings') this.openSettings();
+            else if (action === 'open-openrouter-settings') this._openOpenRouterSettings();
+        });
+
         this.chatSend.addEventListener('click', () => {
             if (this.isRequestInProgress) {
                 this.cancelRequest();
@@ -281,7 +292,7 @@ class AIAssistant {
             this.addMessage('system',
                 'This server does not provide an AI backend. To use the assistant, ' +
                 'add your own OpenAI-compatible endpoint and API key in the ' +
-                '<button onclick="window.aiAssistant?.openSettings()">AI Settings</button>. ' +
+                '<button data-ai-action="open-settings">AI Settings</button>. ' +
                 'Your key stays only in your browser — it is never sent to our server.',
                 true);
         }
@@ -547,12 +558,12 @@ class AIAssistant {
 
         const selectedModel = aiConfig.model === 'custom' ? aiConfig.customModel : aiConfig.model;
         if (!selectedModel) {
-            this.addMessage('system', 'No AI model selected. Please choose a model in the <button onclick="window.aiAssistant?.openSettings()">settings</button>.', true);
+            this.addMessage('system', 'No AI model selected. Please choose a model in the <button data-ai-action="open-settings">settings</button>.', true);
             return;
         }
 
         if (aiConfig.useCustomAPI && (!aiConfig.endpoint || !aiConfig.apiKey)) {
-            this.addMessage('system', 'Direct API configuration is incomplete. Please set up your API endpoint and key in the <button onclick="window.aiAssistant?.openSettings()">settings</button>.', true);
+            this.addMessage('system', 'Direct API configuration is incomplete. Please set up your API endpoint and key in the <button data-ai-action="open-settings">settings</button>.', true);
             return;
         }
 
@@ -565,7 +576,7 @@ class AIAssistant {
                     // H2: escape user-controlled selectedModel before rawHtml=true injection
                     const esc = s => String(s).replace(/[&<>"']/g, c =>
                         ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-                    this.addMessage('system', `Model "${esc(selectedModel)}" is not available. Please open <button onclick="window.aiAssistant?.openSettings()">settings</button> to select a different model.`, true);
+                    this.addMessage('system', `Model "${esc(selectedModel)}" is not available. Please open <button data-ai-action="open-settings">settings</button> to select a different model.`, true);
                     return;
                 }
             } catch (error) {
@@ -699,7 +710,7 @@ class AIAssistant {
                 await this.makeAIRequest(messages, diagramType, originalCode, aiConfig, originalUserPrompt);
             } else {
                 const errorMessage = error.message.toLowerCase().includes('configuration')
-                    ? `${error.message} Check your <button onclick="window.aiAssistant?.openSettings()">AI settings</button>.`
+                    ? `${error.message} Check your <button data-ai-action="open-settings">AI settings</button>.`
                     : `${error.message}`;
                 const hasHtml = errorMessage.includes('<button');
                 // Message shown here is final — rethrowing would surface the same
@@ -1059,14 +1070,14 @@ class AIAssistant {
                 'It resets daily — or you can keep going right now with your own free key:<br>' +
                 '1. Sign up at <a href="https://openrouter.ai" target="_blank" rel="noopener">openrouter.ai</a> (email or Google — no credit card).<br>' +
                 '2. Create a key under <strong>Keys</strong>, and in <strong>Settings → Privacy</strong>, enable free endpoints ("training/logging") so <code>:free</code> models work.<br>' +
-                '3. <button onclick="window.aiAssistant?._openOpenRouterSettings()">Open AI Settings</button> and paste your key under "Use my own API key".<br>' +
+                '3. <button data-ai-action="open-openrouter-settings">Open AI Settings</button> and paste your key under "Use my own API key".<br>' +
                 'Your key stays in your browser — it is never sent to our server.<br>' +
                 'You\'ll get your own 50 free requests/day. Everything else in DocCode works without AI.',
                 true);
         } else if (code === 'per_ip_quota') {
             this.addMessage('system',
                 'You\'ve hit this demo\'s per-user AI limit for today. ' +
-                'Add your own free OpenRouter key in <button onclick="window.aiAssistant?.openSettings()">AI Settings</button> to continue without limits.',
+                'Add your own free OpenRouter key in <button data-ai-action="open-settings">AI Settings</button> to continue without limits.',
                 true);
         }
     }

--- a/demoSite/js/config-ui-models.js
+++ b/demoSite/js/config-ui-models.js
@@ -26,18 +26,24 @@ window.ConfigUIModels = {
         }
 
         try {
-            const response = await fetch('/api/available-models', {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Origin': window.location.origin
+            let data;
+            if (window.__DOCCODE_LITE__) {
+                // Lite (static) build: no /api/available-models endpoint — force BYOK UI.
+                data = { mode: 'byok' };
+            } else {
+                const response = await fetch('/api/available-models', {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Origin': window.location.origin
+                    }
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
                 }
-            });
 
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+                data = await response.json();
             }
-
-            const data = await response.json();
 
             // BYOK branch: server is not in relay mode — show custom-only UI
             if (data.mode && data.mode !== 'relay') {

--- a/demoSite/js/config-ui-templates.js
+++ b/demoSite/js/config-ui-templates.js
@@ -323,7 +323,7 @@ window.ConfigUITemplates = {
                     </div>
                     <div class="config-field" data-depends="ai.useCustomAPI">
                         <label class="config-label">API Key</label>
-                        <form autocomplete="off" onsubmit="return false;" style="display:contents;">
+                        <form autocomplete="off" id="ai-api-key-form" style="display:contents;">
                         <div class="password-input-container">
                             <input type="password" class="config-input" data-config="ai.apiKey" placeholder="sk-..." id="ai-api-key-input" name="ai-api-key" autocomplete="off">
                             <button type="button" class="password-toggle-btn" id="api-key-toggle" aria-label="Toggle password visibility">
@@ -509,7 +509,7 @@ window.ConfigUITemplates = {
                 <div class="config-group">
                     <div class="about-header">
                         <div class="about-logo">
-                            <img src="/favicon.ico" alt="DocCode" class="about-favicon">
+                            <img src="favicon.ico" alt="DocCode" class="about-favicon">
                         </div>
                         <div class="about-title">
                             <h5 id="about-app-name">DocCode - The Kroki Server Frontend</h5>

--- a/demoSite/js/config-ui.js
+++ b/demoSite/js/config-ui.js
@@ -82,6 +82,11 @@ class ConfigUI {
 
         this.setupAIConfigLogic();
         this.setupPasswordToggle();
+
+        // Prevent Enter in the API-key field from submitting/reloading the page.
+        // The strict CSP blocks the inline onsubmit handler, so wire it here.
+        const keyForm = document.getElementById('ai-api-key-form');
+        if (keyForm) keyForm.addEventListener('submit', (e) => e.preventDefault());
     }
 
     setupAIConfigLogic() {

--- a/demoSite/js/modules/drawioIntegration.js
+++ b/demoSite/js/modules/drawioIntegration.js
@@ -25,6 +25,11 @@ class DrawioIntegration {
      * Load configuration from backend
      */
     async loadConfig() {
+        // Lite (static) build: no /api/config endpoint — use the default embed URL.
+        if (window.__DOCCODE_LITE__) {
+            this.updateServerInfo();
+            return;
+        }
         try {
             const response = await fetch('/api/config');
             const config = await response.json();

--- a/demoSite/tests/cspInlineHandlers.test.js
+++ b/demoSite/tests/cspInlineHandlers.test.js
@@ -1,0 +1,56 @@
+/**
+ * CSP inline-handler regression guard.
+ *
+ * The deployment CSP (both the nginx server build and the Lite <meta> build) uses
+ * `script-src 'self' '<hash>'` with NO 'unsafe-inline'. Inline event-handler
+ * attributes (onclick=, onsubmit=, ...) are therefore BLOCKED by the browser —
+ * hashes do not apply to event handlers. Any inline handler in app-authored HTML
+ * (static or injected via innerHTML) silently fails.
+ *
+ * These tests assert the app-authored files contain no inline handler attributes
+ * and that the AI message buttons are wired via delegated data-ai-action instead.
+ * (Vendored bundles in js/vendor/ are third-party and out of scope.)
+ */
+import { test, expect } from 'bun:test';
+import { join } from 'path';
+import { readFileSync } from 'fs';
+
+const jsDir = join(import.meta.dir, '..', 'js');
+
+// App-authored files that build HTML strings or static markup.
+const APP_FILES = [
+    'ai-assistant.js',
+    'config-ui-templates.js',
+    'config-ui.js',
+    'modules/drawioIntegration.js',
+    'config-ui-models.js',
+];
+
+// Matches an inline handler ATTRIBUTE (on<event>="...") but not a JS property
+// assignment (el.onclick = fn — which has a space before '=' and/or a leading dot).
+const INLINE_HANDLER = /\bon(click|submit|change|input|load|error|mouse[a-z]+|key[a-z]+|focus|blur)=["']/;
+
+for (const rel of APP_FILES) {
+    test(`${rel} has no CSP-blocked inline event-handler attributes`, () => {
+        const src = readFileSync(join(jsDir, rel), 'utf8');
+        const offenders = src.split('\n')
+            .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+            .filter(({ line }) => INLINE_HANDLER.test(line));
+        expect(offenders, `inline handler(s) in ${rel}: ${JSON.stringify(offenders)}`).toEqual([]);
+    });
+}
+
+test('AI message buttons are wired via delegated data-ai-action', () => {
+    const src = readFileSync(join(jsDir, 'ai-assistant.js'), 'utf8');
+    // The injected buttons declare data-ai-action ...
+    expect(src).toContain('data-ai-action="open-settings"');
+    expect(src).toContain('data-ai-action="open-openrouter-settings"');
+    // ... and a single delegated listener resolves them.
+    expect(src).toContain("closest('[data-ai-action]')");
+});
+
+test('about-panel favicon uses a relative src (resolves under any base path)', () => {
+    const src = readFileSync(join(jsDir, 'config-ui-templates.js'), 'utf8');
+    expect(src).not.toContain('src="/favicon.ico"');
+    expect(src).toContain('src="favicon.ico"');
+});


### PR DESCRIPTION
Fixes issues found testing the live DocCode Lite demo in a browser. Several also affect the nginx server build (same strict CSP), masked there by relay mode.

- **Inline event handlers blocked by CSP (functional):** the AI system-message buttons used `onclick="..."` and the API-key field used `<form onsubmit="return false;">`. With `script-src 'self' '<hash>'` (no `'unsafe-inline'`), the browser blocks inline handlers (hashes don't apply to them), so "Open AI Settings" / OpenRouter CTAs did nothing and Enter in the key field could reload the page. Converted the 7 buttons to `data-ai-action` + **one delegated listener** on the chat container, and wired the form's `preventDefault` via `addEventListener`. CSP stays strict; buttons work in every mode.
- **favicon 404:** about-panel `<img src="/favicon.ico">` (absolute) → relative `favicon.ico` so it resolves under `/kroki-server/`.
- **Noisy `/api/*` 404s on the static host:** `drawioIntegration` and `config-ui-models` now short-circuit on `window.__DOCCODE_LITE__` — drawio uses the default embed URL, models go straight to the BYOK custom-model UI. No failed requests, no scary console errors.
- **Regression guard:** `tests/cspInlineHandlers.test.js` asserts the app-authored files contain no inline handler attributes and that the delegation + relative favicon are in place.

82 bun + 47 pytest green. JS-only — `server.py`/nginx/compose untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)