### PR TITLE
TISM-26899 Added SSL cert option from ACME Vault PKI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,30 @@ HOSTNAME=localhost
 #   Renewals: the certbot sidecar (docker-compose.acme.yml) runs every 12h;
 #   nginx reloads the new cert every 6h. Also install the daily cron backstop:
 #     sudo crontab -e  →  0 9 * * * /opt/kroki-server/scripts/check-cert-expiry.sh
+# TLS_MODE=acmevaultpki: real certificate from a HashiCorp Vault PKI ACME
+#   directory (e.g. an internal corporate CA), issued + renewed INSIDE the nginx
+#   container via acme.sh (HTTP-01 webroot). The nginx image is rebuilt from
+#   ./nginx-acme on start. Requires:
+#   - HOSTNAME set to the DNS name the cert is for (not localhost, not dotless)
+#   - Host ports 80 (HTTP-01 challenge) and HTTPS_PORT reachable from the CA
+#   - ACME_DIRECTORY_URL and ACME_CONTACT set below
+#   Renewals: acme.sh runs a daily --cron inside the container and reloads nginx.
+#   See docs/acme-tls.md for the full runbook.
 TLS_MODE=selfsigned
 
 # Contact email for Let's Encrypt expiry notices (required when TLS_MODE=acme).
 #ACME_EMAIL=""
+
+# --- Vault PKI ACME (TLS_MODE=acmevaultpki only) -----------------------------
+# ACME directory URL of your Vault PKI intermediate's ACME mount, and the
+# contact email registered for the ACME account. Both are required in this mode.
+#ACME_DIRECTORY_URL=https://vault.it.aws.tenstorrent.com/v1/pki_int/acme/directory
+#ACME_CONTACT=it@tenstorrent.com
+# acme.sh cert key type. Default ec-256 matches the ECDSA-only ssl_ciphers list.
+# Only change to an RSA length (e.g. 2048) if your Vault PKI role issues RSA —
+# you must THEN also widen ssl_ciphers in setup-kroki-server.sh or every TLS
+# handshake will fail.
+#ACME_KEY_LENGTH=ec-256
 
 # Set ACME_STAGING=1 while testing ACME: uses the Let's Encrypt STAGING CA
 # (untrusted certs, but no rate limits). Procedure:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
             env:
               DEPLOY_PROFILE: public
               TLS_MODE: acme
+          - name: public-acmevaultpki
+            env:
+              DEPLOY_PROFILE: public
+              TLS_MODE: acmevaultpki
     steps:
       - uses: actions/checkout@v5
 
@@ -52,6 +56,10 @@ jobs:
           TLS_MODE: ${{ matrix.env.TLS_MODE || '' }}
         run: |
           chmod +x ./setup-kroki-server.sh
+          # Write a real .env so TLS_MODE/DEPLOY_PROFILE take effect: the script
+          # sources .env (which overrides exported env vars), so passing them via
+          # the environment alone is not enough to exercise each mode.
+          printf 'TLS_MODE=%s\nDEPLOY_PROFILE=%s\n' "${TLS_MODE}" "${DEPLOY_PROFILE}" > .env
           ./setup-kroki-server.sh genconfig
 
       - name: Generate dummy ECDSA cert/key
@@ -65,6 +73,12 @@ jobs:
             -signkey /tmp/nginx-test-certs/nginx.key \
             -out /tmp/nginx-test-certs/nginx.crt
           rm /tmp/nginx-test-certs/nginx.csr
+          # acme mode points ssl_certificate at /etc/letsencrypt/live/localhost/;
+          # acmevaultpki + selfsigned use /etc/nginx/certs. Provide certs at both
+          # so nginx -t (which loads the cert files) passes for every mode.
+          mkdir -p /tmp/letsencrypt/live/localhost
+          cp /tmp/nginx-test-certs/nginx.crt /tmp/letsencrypt/live/localhost/fullchain.pem
+          cp /tmp/nginx-test-certs/nginx.key /tmp/letsencrypt/live/localhost/privkey.pem
 
       - name: Validate nginx.conf with nginx -t (${{ matrix.name }})
         run: |
@@ -73,6 +87,7 @@ jobs:
             --add-host core:127.0.0.1 \
             -v "$(pwd)/nginx.conf:/etc/nginx/nginx.conf:ro" \
             -v "/tmp/nginx-test-certs:/etc/nginx/certs:ro" \
+            -v "/tmp/letsencrypt:/etc/letsencrypt:ro" \
             nginx:1.28-alpine nginx -t
 
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ For a public deployment, see:
 - **[docs/production-deployment.md](docs/production-deployment.md)** — threat model,
   quick recipe, and reference for every knob: `TLS_MODE`, `DEPLOY_PROFILE`,
   `RENDER_CACHE_ENABLED`, `COMPOSE_PROFILES`, AI posture, `GUNICORN_*`, sizing
-- **[docs/acme-tls.md](docs/acme-tls.md)** — real TLS via Let's Encrypt (staging-first
-  procedure, renewal mechanics, rollback)
+- **[docs/acme-tls.md](docs/acme-tls.md)** — real TLS via Let's Encrypt
+  (`acme`, staging-first procedure, renewal, rollback) or a HashiCorp Vault PKI
+  ACME directory (`acmevaultpki`, cert issued/renewed in-container via acme.sh)
 - **[docs/public-demo-hosting-runbook.md](docs/public-demo-hosting-runbook.md)** —
   Hetzner provisioning, DNS, OpenRouter relay setup, monitoring, abuse response
 

--- a/docker-compose.acmevaultpki.yml
+++ b/docker-compose.acmevaultpki.yml
@@ -1,0 +1,40 @@
+# Vault PKI ACME overlay — applied automatically by setup-kroki-server.sh when
+# TLS_MODE=acmevaultpki. Never used in the default self-signed setup or the
+# Let's Encrypt acme mode (docker-compose.acme.yml).
+#
+# Unlike the certbot-based acme mode, issuance + renewal happen INSIDE the nginx
+# container via acme.sh (built into ./nginx-acme). The cert is obtained from a
+# HashiCorp Vault PKI ACME directory using an HTTP-01 webroot challenge.
+#
+# Compose v2 merge semantics (uniqueness key = target/mount path):
+#   - ports APPEND: base publishes ${HTTPS_PORT:-8443}:8443; this adds 80:8080
+#     for the HTTP-01 challenge + HTTP->HTTPS redirect.
+#   - the /etc/nginx/certs volume OVERRIDES the base read-only bind mount with a
+#     writable named volume, so acme.sh can install the issued cert there. The
+#     rendered nginx.conf still points at /etc/nginx/certs/nginx.{crt,key}.
+#   - /acme (acme.sh state + webroot) is appended as a new named volume.
+#   - image/build: the nginx service is rebuilt from ./nginx-acme (acme.sh baked
+#     in) and retagged, replacing the stock nginx:1.28-alpine from the base file.
+#   - relative paths (build context) resolve against the base docker-compose.yml.
+
+services:
+  nginx:
+    build: ./nginx-acme
+    image: kroki-nginx-acme:latest
+    ports:
+      - "${ACME_HTTP_PORT:-80}:8080"
+    environment:
+      # FQDN is the DNS name the cert is issued for. HOSTNAME is exported from
+      # .env by setup-kroki-server.sh (the bash builtin is deliberately ignored,
+      # same caveat as the Let's Encrypt acme mode).
+      - FQDN=${HOSTNAME}
+      - ACME_DIRECTORY_URL=${ACME_DIRECTORY_URL}
+      - ACME_CONTACT=${ACME_CONTACT}
+      - ACME_KEY_LENGTH=${ACME_KEY_LENGTH:-ec-256}
+    volumes:
+      - nginx_acme_certs:/etc/nginx/certs
+      - nginx_acme_data:/acme
+
+volumes:
+  nginx_acme_certs:
+  nginx_acme_data:

--- a/docs/acme-tls.md
+++ b/docs/acme-tls.md
@@ -116,3 +116,98 @@ Always stop the stack before switching `TLS_MODE` between `acme` and
 Switching while the stack is running leaves the certbot container as an orphan
 (compose only warns). The `--remove-orphans` flag in `restart` and `stop` cleans
 these up automatically.
+
+---
+
+# Real TLS with a Vault PKI ACME directory (TLS_MODE=acmevaultpki)
+
+Use this mode to obtain the nginx certificate from a **HashiCorp Vault PKI ACME
+directory** (a common pattern for internal corporate CAs) instead of Let's
+Encrypt. Unlike the `acme` mode (which uses a host-side certbot sidecar),
+issuance and renewal happen **entirely inside the nginx container** via
+[`acme.sh`](https://github.com/acmesh-official/acme.sh), baked into a custom
+image built from `./nginx-acme`.
+
+Add these lines to your `.env`:
+
+```bash
+HOSTNAME=kroki.it.example.com   # DNS name the cert is issued for
+HTTPS_PORT=443
+TLS_MODE=acmevaultpki
+ACME_DIRECTORY_URL=https://vault.it.aws.tenstorrent.com/v1/pki_int/acme/directory
+ACME_CONTACT=it@tenstorrent.com
+```
+
+Then:
+
+```bash
+./setup-kroki-server.sh start
+```
+
+## How it works
+
+1. **Custom image** — `setup-kroki-server.sh start` builds `kroki-nginx-acme`
+   from `nginx-acme/Dockerfile` (stock `nginx:1.28-alpine` + `acme.sh`) and the
+   `docker-compose.acmevaultpki.yml` overlay is layered on the base compose file.
+2. **Bootstrap** — the container's entrypoint drops an **ECDSA self-signed**
+   placeholder cert into `/etc/nginx/certs/nginx.{crt,key}` so nginx can start
+   and serve the HTTP-01 challenge on port 80 (→ container `:8080`). ECDSA is
+   mandatory: the rendered `nginx.conf` uses an ECDSA-only cipher list, so an
+   RSA cert would fail every handshake.
+3. **Issuance** — once nginx is up, `acme.sh` registers an account against
+   `ACME_DIRECTORY_URL` and issues the real cert in **webroot mode**
+   (`/acme/webroot`, served by the `:8080` listener), then installs it over the
+   bootstrap cert and reloads nginx.
+4. **Renewal** — `acme.sh --cron` runs daily inside the container and reloads
+   nginx when the cert is renewed. Cert state and the issued cert live on the
+   `nginx_acme_data` and `nginx_acme_certs` named volumes, so they survive
+   restarts.
+
+## Prerequisites
+
+1. **DNS** — `HOSTNAME` resolves to this box from wherever the Vault ACME server
+   performs the HTTP-01 validation callback.
+2. **Ports** — host ports `80` (HTTP-01) and `HTTPS_PORT` are reachable.
+3. **Trust** — the container connects to `ACME_DIRECTORY_URL` over HTTPS, so the
+   Vault endpoint's certificate must be trusted by the image's CA bundle. If
+   Vault presents a cert from a private root, that root must chain to a publicly
+   trusted CA (as is the case for the example URL above).
+4. **Key type** — the default `ACME_KEY_LENGTH=ec-256` matches the ECDSA-only
+   `ssl_ciphers`. Your Vault PKI role must permit issuing EC (P-256) certs. If it
+   only issues RSA, set `ACME_KEY_LENGTH=2048` **and** widen `ssl_ciphers` in
+   `setup-kroki-server.sh`, otherwise TLS handshakes will fail.
+
+## Verifying
+
+```bash
+# Watch issuance in the nginx container logs:
+./setup-kroki-server.sh logs   # look for "[entrypoint] Issuing certificate for ..."
+
+# Confirm the served cert's issuer is your Vault PKI (not the bootstrap self-sign):
+curl -vk https://kroki.it.example.com/ 2>&1 | grep -i "issuer"
+```
+
+## Troubleshooting
+
+- **Still serving the self-signed bootstrap cert** — issuance failed (check the
+  logs). Common causes: the HTTP-01 callback can't reach `:80`, DNS doesn't
+  resolve to this box, or the Vault role rejected the key type. The container
+  keeps the bootstrap cert and retries on the daily cron.
+- **Rebuild the image after editing `nginx-acme/`** — `restart` and `start`
+  run `docker compose build nginx` automatically before `up`.
+
+## Switching modes
+
+Stop the stack before switching `TLS_MODE` (the same orphan-cleanup note as
+above applies — `restart`/`stop` pass `--remove-orphans`):
+
+```bash
+./setup-kroki-server.sh stop
+# edit TLS_MODE in .env
+./setup-kroki-server.sh start
+```
+
+`./setup-kroki-server.sh clean` removes the `nginx_acme_certs` / `nginx_acme_data`
+volumes (via `down -v`); the cert is simply re-issued on the next start. Vault
+PKI internal CAs generally do not impose Let's Encrypt-style duplicate-cert rate
+limits, so this is safe.

--- a/nginx-acme/Dockerfile
+++ b/nginx-acme/Dockerfile
@@ -1,0 +1,35 @@
+# Custom nginx image for TLS_MODE=acmevaultpki. Same nginx version as the base
+# compose (nginx:1.28-alpine) with acme.sh baked in so the certificate is
+# issued and renewed against a HashiCorp Vault PKI ACME directory entirely
+# inside the container (HTTP-01 webroot). Only used when TLS_MODE=acmevaultpki;
+# the selfsigned and acme modes keep using the stock nginx:1.28-alpine image.
+FROM nginx:1.28-alpine
+
+# bash: entrypoint shell. curl/openssl/socat: acme.sh runtime deps.
+# ca-certificates: trust store for the HTTPS connection to the Vault directory.
+RUN apk add --no-cache bash curl openssl socat ca-certificates tini
+
+# acme.sh reads these to locate its state; /acme is a persisted named volume.
+ENV ACME_HOME=/acme \
+    LE_WORKING_DIR=/acme \
+    LE_CONFIG_HOME=/acme \
+    CERT_HOME=/acme/certs \
+    PATH="/acme:${PATH}"
+
+# Pin acme.sh to a tagged release for reproducible builds.
+RUN mkdir -p /acme /etc/nginx/certs \
+ && curl -fsSL https://github.com/acmesh-official/acme.sh/archive/refs/tags/3.1.0.tar.gz \
+      | tar -xz -C /tmp \
+ && cd /tmp/acme.sh-3.1.0 \
+ && ./acme.sh --install --home /acme --no-cron --no-profile \
+ && rm -rf /tmp/acme.sh-3.1.0
+
+COPY entrypoint.sh /usr/local/bin/kroki-acme-entrypoint.sh
+RUN chmod +x /usr/local/bin/kroki-acme-entrypoint.sh
+
+# 8080: HTTP-01 challenge + HTTP->HTTPS redirect. 8443: HTTPS (matches nginx.conf).
+EXPOSE 8080 8443
+
+# tini reaps the acme.sh background renewal process; the entrypoint execs nginx.
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/kroki-acme-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx-acme/entrypoint.sh
+++ b/nginx-acme/entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Entrypoint for the TLS_MODE=acmevaultpki nginx image.
+#
+# Flow (mirrors the reference tt-topsheet-generator setup, adapted to kroki's
+# port scheme and ECDSA-only cipher list):
+#   1. Drop an ECDSA self-signed bootstrap cert so nginx can start immediately
+#      (the rendered nginx.conf uses an ECDSA-only cipher list, so the bootstrap
+#      cert MUST be ECDSA too — an RSA cert would fail every TLS handshake).
+#   2. Register an ACME account against the Vault PKI directory.
+#   3. Once nginx is serving the HTTP-01 listener (:8080), issue the real cert in
+#      webroot mode, install it over the bootstrap cert, and reload nginx.
+#   4. Run acme.sh --cron daily to renew (Vault-issued certs are short-lived).
+#
+# nginx.conf itself is rendered on the host by setup-kroki-server.sh and mounted
+# read-only, so this entrypoint does no template/envsubst processing.
+set -euo pipefail
+
+: "${FQDN:?FQDN must be set (maps to HOSTNAME from .env)}"
+: "${ACME_DIRECTORY_URL:?ACME_DIRECTORY_URL must be set}"
+: "${ACME_CONTACT:?ACME_CONTACT must be set}"
+ACME_KEY_LENGTH="${ACME_KEY_LENGTH:-ec-256}"
+
+CERT_DIR=/etc/nginx/certs
+WEBROOT=/acme/webroot
+mkdir -p "${CERT_DIR}" "${WEBROOT}/.well-known/acme-challenge"
+
+# acme.sh stores EC certs under <domain>_ecc; RSA under <domain>. --install-cert
+# needs --ecc for EC keys to resolve the right path.
+ECC_FLAG=""
+case "${ACME_KEY_LENGTH}" in
+  ec-*) ECC_FLAG="--ecc" ;;
+esac
+
+# 1. Bootstrap ECDSA self-signed cert (only if we don't already have one on the
+#    persisted volume) so nginx starts and can serve the HTTP-01 challenge.
+if [ ! -s "${CERT_DIR}/nginx.crt" ] || [ ! -s "${CERT_DIR}/nginx.key" ]; then
+  echo "[entrypoint] No cert found — generating ECDSA self-signed bootstrap cert for ${FQDN}"
+  openssl ecparam -name prime256v1 -genkey -noout -out "${CERT_DIR}/nginx.key"
+  openssl req -new -x509 -key "${CERT_DIR}/nginx.key" \
+    -out "${CERT_DIR}/nginx.crt" -days 1 -subj "/CN=${FQDN}" >/dev/null 2>&1
+  chmod 600 "${CERT_DIR}/nginx.key"
+fi
+
+# 2. Register the ACME account with the Vault PKI directory (idempotent).
+/acme/acme.sh --register-account \
+  --server "${ACME_DIRECTORY_URL}" \
+  --accountemail "${ACME_CONTACT}" || true
+
+# 3 + 4. Issue/install the real cert and then renew forever, in the background.
+(
+  # Wait for nginx to start serving the HTTP-01 listener on :8080.
+  for _ in $(seq 1 30); do
+    if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/ 2>/dev/null)" != "000" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  if [ ! -f "/acme/${FQDN}_ecc/${FQDN}.cer" ] && [ ! -f "/acme/${FQDN}/${FQDN}.cer" ]; then
+    echo "[entrypoint] Issuing certificate for ${FQDN} via ${ACME_DIRECTORY_URL}"
+    if ! /acme/acme.sh --issue \
+      --server "${ACME_DIRECTORY_URL}" \
+      -d "${FQDN}" \
+      --webroot "${WEBROOT}" \
+      --keylength "${ACME_KEY_LENGTH}"; then
+      echo "[entrypoint] Initial cert issuance failed — keeping bootstrap cert; will retry via cron"
+      exit 0
+    fi
+
+    # shellcheck disable=SC2086
+    /acme/acme.sh --install-cert -d "${FQDN}" ${ECC_FLAG} \
+      --key-file       "${CERT_DIR}/nginx.key" \
+      --fullchain-file "${CERT_DIR}/nginx.crt" \
+      --reloadcmd      "nginx -s reload || true"
+  fi
+
+  # Daily renewal check. Webroot mode → no port conflict with nginx; --install-cert
+  # ran above wires the reload so renewed certs are picked up automatically.
+  while true; do
+    sleep 86400
+    /acme/acme.sh --cron --server "${ACME_DIRECTORY_URL}" || true
+  done
+) &
+
+exec "$@"

--- a/setup-kroki-server.sh
+++ b/setup-kroki-server.sh
@@ -51,13 +51,21 @@ fi
 # PR-4 (compose-footprint) enables the companions profile by default.
 export COMPOSE_PROFILES="${COMPOSE_PROFILES-companions}"
 
-# TLS mode: selfsigned (default, closed-network) or acme (PR-7).
+# TLS mode: selfsigned (default, closed-network), acme (Let's Encrypt via
+# certbot), or acmevaultpki (a Vault PKI ACME directory via acme.sh baked into a
+# custom nginx image — see docker-compose.acmevaultpki.yml / nginx-acme/).
 TLS_MODE="${TLS_MODE:-selfsigned}"
 
 # ACME/Let's Encrypt paths and options (only used when TLS_MODE=acme).
 LETSENCRYPT_DIR="${SCRIPT_DIR}/letsencrypt"
 CERTBOT_WEBROOT_DIR="${SCRIPT_DIR}/certbot-webroot"
 ACME_HTTP_PORT="${ACME_HTTP_PORT:-80}"
+
+# Vault PKI ACME options (only used when TLS_MODE=acmevaultpki). ACME_DIRECTORY_URL
+# and ACME_CONTACT are required (validated in validate_acmevaultpki_config); they
+# are passed to the nginx container's acme.sh via docker-compose.acmevaultpki.yml.
+# ACME_KEY_LENGTH defaults to ec-256 to match the ECDSA-only ssl_ciphers below.
+ACME_KEY_LENGTH="${ACME_KEY_LENGTH:-ec-256}"
 
 # Deployment profile: private (default, closed-network) or public (PR-5).
 DEPLOY_PROFILE="${DEPLOY_PROFILE:-private}"
@@ -90,7 +98,7 @@ NGINX_SECURITY_HEADERS="    add_header X-Content-Type-Options nosniff;
 # the shared fragment is restated inside every location that adds its own
 # add_header, so HSTS is covered everywhere in acme mode). Initial max-age=86400
 # (1 day) for rollback safety — raise to 31536000 a week after launch.
-if [ "$TLS_MODE" = "acme" ]; then
+if [ "$TLS_MODE" = "acme" ] || [ "$TLS_MODE" = "acmevaultpki" ]; then
     NGINX_SECURITY_HEADERS="${NGINX_SECURITY_HEADERS}
     add_header Strict-Transport-Security \"max-age=86400\" always;"
 fi
@@ -204,6 +212,8 @@ check_dependencies() {
     DOCKER_COMPOSE="$DOCKER_COMPOSE -f $DOCKER_COMPOSE_FILE"
     if [ "$TLS_MODE" = "acme" ]; then
         DOCKER_COMPOSE="$DOCKER_COMPOSE -f ${SCRIPT_DIR}/docker-compose.acme.yml"
+    elif [ "$TLS_MODE" = "acmevaultpki" ]; then
+        DOCKER_COMPOSE="$DOCKER_COMPOSE -f ${SCRIPT_DIR}/docker-compose.acmevaultpki.yml"
     fi
 }
 
@@ -308,6 +318,39 @@ ensure_acme_cert() {
     echo "Certificate issued successfully."
 }
 
+# Validate Vault PKI ACME configuration: called from start/restart when
+# TLS_MODE=acmevaultpki. Issuance itself happens inside the nginx container
+# (acme.sh), so there is no host-side certbot step — we only sanity-check that
+# the required inputs are present before building/starting the stack.
+validate_acmevaultpki_config() {
+    # Require a literal HOSTNAME= line in .env — the bash builtin can shadow it
+    # (same rationale as the Let's Encrypt acme mode).
+    if [ ! -f "${SCRIPT_DIR}/.env" ] || ! grep -q '^HOSTNAME=' "${SCRIPT_DIR}/.env"; then
+        echo "Error: TLS_MODE=acmevaultpki requires HOSTNAME to be set explicitly in .env (not just the shell environment)."
+        echo "  Add a line like: HOSTNAME=kroki.it.example.com"
+        exit 1
+    fi
+    if [ "${DEFAULT_HOSTNAME}" = "localhost" ] || ! echo "${DEFAULT_HOSTNAME}" | grep -q '\.'; then
+        echo "Error: TLS_MODE=acmevaultpki requires HOSTNAME to be a DNS name (got '${DEFAULT_HOSTNAME}')."
+        echo "  HOSTNAME must contain at least one dot and must not be 'localhost'."
+        exit 1
+    fi
+    if [ -z "${ACME_DIRECTORY_URL:-}" ]; then
+        echo "Error: TLS_MODE=acmevaultpki requires ACME_DIRECTORY_URL to be set in .env."
+        echo "  Example: ACME_DIRECTORY_URL=https://vault.example.com/v1/pki_int/acme/directory"
+        exit 1
+    fi
+    if [ -z "${ACME_CONTACT:-}" ]; then
+        echo "Error: TLS_MODE=acmevaultpki requires ACME_CONTACT to be set in .env."
+        echo "  Example: ACME_CONTACT=it@example.com"
+        exit 1
+    fi
+    if [ "${DEFAULT_HTTPS_PORT}" != "443" ]; then
+        echo "Warning: TLS_MODE=acmevaultpki expects HTTPS_PORT=443; the HTTP->HTTPS redirect assumes the standard port."
+        echo "  Current HTTPS_PORT=${DEFAULT_HTTPS_PORT}. Proceeding, but the redirect may point clients at the wrong port."
+    fi
+}
+
 # Function to build demo site
 build_demo_site() {
     echo "Building demo site container..."
@@ -365,22 +408,32 @@ create_nginx_config() {
     local ssl_cert="/etc/nginx/certs/nginx.crt"
     local ssl_key="/etc/nginx/certs/nginx.key"
     local acme_http_server=""
+    # Webroot served by the :8080 HTTP-01 listener. certbot (acme mode) writes to
+    # /var/www/certbot; acme.sh (acmevaultpki mode) writes to /acme/webroot. In
+    # acmevaultpki mode the cert paths stay at /etc/nginx/certs/nginx.{crt,key}
+    # (acme.sh installs there over the ECDSA bootstrap cert), so the SSL block is
+    # byte-identical to selfsigned mode.
+    local acme_webroot=""
     if [ "$TLS_MODE" = "acme" ]; then
         ssl_cert="/etc/letsencrypt/live/${DEFAULT_HOSTNAME}/fullchain.pem"
         ssl_key="/etc/letsencrypt/live/${DEFAULT_HOSTNAME}/privkey.pem"
+        acme_webroot="/var/www/certbot"
+    elif [ "$TLS_MODE" = "acmevaultpki" ]; then
+        acme_webroot="/acme/webroot"
+    fi
+    if [ -n "$acme_webroot" ]; then
         # Note: \$host and \$request_uri below are nginx runtime variables;
         # they are escaped here so they pass through the heredoc unexpanded
         # and reach nginx.conf as literal $host / $request_uri.
         acme_http_server="
     # ACME HTTP-01 challenge listener + HTTP->HTTPS redirect.
-    # Certbot renewal webroot requests are served from /var/www/certbot
-    # (mounted from ./certbot-webroot by docker-compose.acme.yml).
+    # Renewal webroot requests are served from ${acme_webroot}.
     server {
         listen 0.0.0.0:8080;
         server_name ${DEFAULT_HOSTNAME};
 
         location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
+            root ${acme_webroot};
         }
 
         location / {
@@ -568,7 +621,7 @@ check_services() {
     # public IP back to the same host (no hairpin/NAT loopback). If the public
     # hostname check failed, retry via 127.0.0.1 with --resolve so TLS SNI
     # still matches the real hostname.
-    if [ "$TLS_MODE" = "acme" ]; then
+    if [ "$TLS_MODE" = "acme" ] || [ "$TLS_MODE" = "acmevaultpki" ]; then
         echo "Public hostname check failed — trying hairpin-NAT fallback via 127.0.0.1..."
         if curl -k -s -o /dev/null -w "%{http_code}" \
             --resolve "${DEFAULT_HOSTNAME}:${DEFAULT_HTTPS_PORT}:127.0.0.1" \
@@ -710,7 +763,7 @@ show_help() {
     echo "              prints resolved TLS_MODE, DEPLOY_PROFILE, COMPOSE_PROFILES"
     echo ""
     echo "Deployment parameters (set via .env or environment):"
-    echo "  TLS_MODE             selfsigned (default) | acme"
+    echo "  TLS_MODE             selfsigned (default) | acme | acmevaultpki"
     echo "  DEPLOY_PROFILE       private (default) | public"
     echo "  COMPOSE_PROFILES     companions (default) | empty for core-only"
     echo "  RENDER_CACHE_ENABLED true (default) | false"
@@ -724,6 +777,12 @@ show_help() {
     echo "  ACME_STAGING         Set to 1 to use the LE staging CA (test first!)"
     echo "  ACME_HTTP_PORT       Host port for HTTP-01 challenge/redirect (default: 80)"
     echo "  CERT_ALERT_WEBHOOK   Optional webhook URL for scripts/check-cert-expiry.sh"
+    echo ""
+    echo "Vault PKI ACME parameters (TLS_MODE=acmevaultpki only):"
+    echo "  ACME_DIRECTORY_URL   Vault PKI ACME directory URL (required)"
+    echo "  ACME_CONTACT         Contact email for the ACME account (required)"
+    echo "  ACME_KEY_LENGTH      Cert key type (default: ec-256, matches ssl_ciphers)"
+    echo "  ACME_HTTP_PORT       Host port for HTTP-01 challenge/redirect (default: 80)"
     echo ""
 }
 
@@ -743,12 +802,20 @@ case "$COMMAND" in
         if [ "$TLS_MODE" = "acme" ]; then
             validate_acme_config
             ensure_acme_cert
+        elif [ "$TLS_MODE" = "acmevaultpki" ]; then
+            # Issuance happens inside the nginx container (acme.sh); no host-side
+            # cert step. The custom nginx image is (re)built just before 'up'.
+            validate_acmevaultpki_config
         else
             generate_certs
         fi
         create_nginx_config
         build_demo_site
         ensure_kroki_core
+        if [ "$TLS_MODE" = "acmevaultpki" ]; then
+            echo "Building custom nginx image with acme.sh (Vault PKI)..."
+            $DOCKER_COMPOSE build nginx
+        fi
         echo "Starting services with Docker Compose..."
 
         if [ -f "$DOCKER_COMPOSE_FILE" ]; then
@@ -802,11 +869,17 @@ case "$COMMAND" in
         if [ "$TLS_MODE" = "acme" ]; then
             validate_acme_config
             ensure_acme_cert
+        elif [ "$TLS_MODE" = "acmevaultpki" ]; then
+            validate_acmevaultpki_config
         else
             generate_certs
         fi
         create_nginx_config
         ensure_kroki_core
+        if [ "$TLS_MODE" = "acmevaultpki" ]; then
+            echo "Building custom nginx image with acme.sh (Vault PKI)..."
+            $DOCKER_COMPOSE build nginx
+        fi
         echo "Starting services with Docker Compose..."
         $DOCKER_COMPOSE up -d
         sleep 5


### PR DESCRIPTION
**What it does**
It mirrors the reference repo's approach: a custom nginx image with acme.sh baked in that (1) drops an ECDSA self-signed bootstrap cert so nginx starts, (2) registers an ACME account against your Vault PKI directory, (3) issues the real cert via HTTP-01 webroot, installs it, and reloads nginx, and (4) runs a daily in-container renewal loop. Unlike the existing Let's Encrypt acme mode (host-side certbot sidecar), issuance/renewal happen entirely inside the nginx container.

**New files**

- nginx-acme/Dockerfile — nginx:1.28-alpine + acme.sh (pinned 3.1.0) + tini.
- nginx-acme/entrypoint.sh — bootstrap → register → issue (webroot) → install → daily --cron.
- docker-compose.acmevaultpki.yml — overlay that rebuilds nginx from ./nginx-acme, appends 80→8080 for the challenge, passes FQDN/ACME_DIRECTORY_URL/ACME_CONTACT/ACME_KEY_LENGTH, and swaps the read-only /etc/nginx/certs bind mount for a writable named volume so acme.sh can install the cert.

**Changed files**

- setup-kroki-server.sh — new validate_acmevaultpki_config(), overlay selection, cert/webroot paths + HSTS in the rendered nginx.conf, an image build before up, and start/restart/help wiring.
- .env.example — documents the mode plus ACME_DIRECTORY_URL / ACME_CONTACT (with your Tenstorrent values) and ACME_KEY_LENGTH.
- docs/acme-tls.md, README.md — full runbook + reference.
- .github/workflows/ci.yml — new public-acmevaultpki matrix row; also fixed the job so the matrix TLS_MODE is honored (it was being silently overridden by the bootstrapped .env, so the acme row had been validating self-signed).

**Key design decisions**

- ECDSA cert (ACME_KEY_LENGTH=ec-256 default) — kroki's nginx.conf uses an ECDSA-only cipher list, so both the bootstrap and issued certs must be EC or every handshake fails. Documented how to switch to RSA if your Vault role requires it.
- Cert paths unchanged (/etc/nginx/certs/nginx.{crt,key}) — keeps the SSL block byte-identical to self-signed; the overlay just makes that mount writable via Compose's target-key volume override.

**Validation done locally**

- shellcheck clean on both scripts.
- Rendered config for acmevaultpki shows HSTS, the /acme/webroot HTTP-01 block, and correct cert paths.
- No regression: self-signed output is byte-identical; acme differs only by a comment line.
- docker compose config confirms the merge (image override, port append, writable certs volume, /acme volume).

To use it, set these in .env and run ./setup-kroki-server.sh start:

HOSTNAME=kroki.it.example.com
HTTPS_PORT=443
TLS_MODE=acmevaultpki
ACME_DIRECTORY_URL=https://vault.it.aws.tenstorrent.com/v1/pki_int/acme/directory
ACME_CONTACT=it@tenstorrent.com