### PR TITLE
fix(csp): allow Google Fonts in nginx CSP

### DIFF
--- a/setup-kroki-server.sh
+++ b/setup-kroki-server.sh
@@ -84,7 +84,7 @@ IMPORTMAP_SHA256="sha256-LvNDiZbbhmyHUBohi9wADi3l/thqDrW+o+NEgB+bZVY="
 NGINX_SECURITY_HEADERS="    add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection \"1; mode=block\";
     add_header X-Frame-Options SAMEORIGIN;
-    add_header Content-Security-Policy \"default-src 'self'; script-src 'self' '${IMPORTMAP_SHA256}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https:; frame-src 'self' ${DRAWIO_ORIGIN}; object-src 'none'; base-uri 'self'; frame-ancestors 'self'\" always;"
+    add_header Content-Security-Policy \"default-src 'self'; script-src 'self' '${IMPORTMAP_SHA256}'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https:; frame-src 'self' ${DRAWIO_ORIGIN}; object-src 'none'; base-uri 'self'; frame-ancestors 'self'\" always;"
 # ACME mode: append HSTS to the shared fragment so it is inherited everywhere
 # (http-level add_header is inherited only when a location/server defines none;
 # the shared fragment is restated inside every location that adds its own


### PR DESCRIPTION
## Summary
- `demoSite/css/base.css` imports Inter/JetBrains Mono from `fonts.googleapis.com`, but the nginx CSP set in `setup-kroki-server.sh` only allowed `style-src 'self' 'unsafe-inline'` and had no `font-src`, so browsers block the stylesheet with a CSP violation ("Not Secure"-adjacent console error reported on doccode.local.tenstorrent.com).
- Adds `https://fonts.googleapis.com` to `style-src` and a new `font-src 'self' https://fonts.gstatic.com`, matching what the lite static build (`build-lite.mjs`) already allows.

## Test plan
- [x] `nginx-config` CI job validates the generated nginx config still parses/lints
- [ ] Manually verify in a browser against a deployment that the Google Fonts stylesheet loads without a CSP console error